### PR TITLE
Update functionality test to use carta protobuf 1.2

### DIFF
--- a/src/test/ACCESS_CARTA_DEFAULT.test.ts
+++ b/src/test/ACCESS_CARTA_DEFAULT.test.ts
@@ -50,16 +50,16 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
         Connection.binaryType = "arraybuffer";
         Connection.onopen = OnOpen;        
         
-        async function OnOpen (this: WebSocket, ev: Event) {
+        async function OnOpen(this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: ""
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();
@@ -78,16 +78,16 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
         Connection.binaryType = "arraybuffer";
         Connection.onopen = OnOpen;
 
-        async function OnOpen (this: WebSocket, ev: Event) {
+        async function OnOpen(this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();
@@ -110,7 +110,7 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
             Connection.binaryType = "arraybuffer";
             Connection.onopen = OnOpen;
 
-            function OnOpen (this: WebSocket, ev: Event) {
+            function OnOpen(this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 done();
             }
@@ -118,18 +118,18 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
     
         test(`assert the received EventName is "REGISTER_VIEWER_ACK" within ${connectTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "",
+                    sessionId: 0,
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
                 Connection.onmessage = (event: MessageEvent) => {
-                    expect(event.data.byteLength).toBeGreaterThan(40);
-                    
-                    const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
-                    expect(eventName).toBe("REGISTER_VIEWER_ACK");
+                    const eventHeader16 = new Uint16Array(event.data, 0, 2);
+                    const eventType = eventHeader16[0];
+                    expect(event.data.byteLength).toBeGreaterThan(0);
+                    expect(eventType).toEqual(Utility.EventType.RegisterViewerAck);
 
                     resolve();
                 };
@@ -138,14 +138,14 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
     
         test(`assert the "REGISTER_VIEWER_ACK.session_id" is not None.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "",
+                    sessionId: 0,
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {            
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.sessionId).toBeDefined();
                         console.log(`Registered session ID is ${RegisterViewerAck.sessionId} @${new Date()}`);
@@ -158,14 +158,14 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
     
         test(`assert the "REGISTER_VIEWER_ACK.success" is true.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "",
+                    sessionId: 0,
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();
@@ -176,14 +176,14 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
     
         test(`assert the "REGISTER_VIEWER_ACK.session_type" is "CARTA.SessionType.NEW".`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "",
+                    sessionId: 0,
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.sessionType).toBe(CARTA.SessionType.NEW);
                         resolve();

--- a/src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts
+++ b/src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts
@@ -99,7 +99,7 @@ describe("ACCESS_CARTA_DEFAULT_CONCURRENT test: Testing multiple concurrent conn
         
         promiseSet.forEach( (item, index, array) => {
             array[index] = new Promise( (resolve, reject) => {
-                Utility.getEvent(Connection[index], "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection[index], CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         registerViewerAck[index] = RegisterViewerAck;
@@ -116,9 +116,9 @@ describe("ACCESS_CARTA_DEFAULT_CONCURRENT test: Testing multiple concurrent conn
         Promise.all(promiseSet).then( () => done() );
 
         for (let connection of Connection) {
-            Utility.setEvent(connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            Utility.setEvent(connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );

--- a/src/test/ACCESS_CARTA_RESUME_SESSION.test.ts
+++ b/src/test/ACCESS_CARTA_RESUME_SESSION.test.ts
@@ -6,7 +6,7 @@ let connectTimeout = config.timeout.connection;
 
 describe("ACCESS_CARTA_RESUME_SESSION test: Testing connections to the backend with a wrong session id.", () => {
     
-    describe(`send EventName: "REGISTER_VIEWER" to CARTA "${testServerUrl}" with session_id "an-unknown-session-id" & api_key "1234".`, 
+    describe(`send EventName: "REGISTER_VIEWER" to CARTA "${testServerUrl}" with session_id = -1 & api_key = "1234".`, 
     () => {
         let Connection: WebSocket;
     
@@ -25,14 +25,14 @@ describe("ACCESS_CARTA_RESUME_SESSION test: Testing connections to the backend w
     
         test(`assert the received EventName is "REGISTER_VIEWER_ACK" within ${connectTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "an-unknown-session-id", 
+                    sessionId: -1, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         resolve();
                     }
@@ -42,14 +42,14 @@ describe("ACCESS_CARTA_RESUME_SESSION test: Testing connections to the backend w
                
         test(`assert the "REGISTER_VIEWER_ACK.success" is false.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "an-unknown-session-id", 
+                    sessionId: -1, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.success).toBe(false);
                         resolve();
@@ -60,14 +60,14 @@ describe("ACCESS_CARTA_RESUME_SESSION test: Testing connections to the backend w
     
         test(`assert the "REGISTER_VIEWER_ACK.message" is not empty.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "an-unknown-session-id", 
+                    sessionId: -1, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.message).toBeDefined();
                         expect(RegisterViewerAck.message).not.toEqual("");
@@ -82,14 +82,14 @@ describe("ACCESS_CARTA_RESUME_SESSION test: Testing connections to the backend w
 
         test(`assert the "REGISTER_VIEWER_ACK.session_type" is 1.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "an-unknown-session-id", 
+                    sessionId: -1, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.sessionType).toEqual(1);
                         resolve();

--- a/src/test/ACCESS_CARTA_UNKNOWN_APIKEY.test.ts
+++ b/src/test/ACCESS_CARTA_UNKNOWN_APIKEY.test.ts
@@ -6,7 +6,7 @@ let connectTimeout = config.timeout.connection;
 
 describe("ACCESS_CARTA_UNKNOWN_APIKEY tests", () => {
     
-    describe(`send EventName: "REGISTER_VIEWER" to CARTA "${testServerUrl}" with session_id "" & api_key "5678".`, 
+    describe(`send EventName: "REGISTER_VIEWER" to CARTA "${testServerUrl}" with session_id = 0 & api_key = "5678".`, 
     () => {
         let Connection: WebSocket;
     
@@ -25,18 +25,18 @@ describe("ACCESS_CARTA_UNKNOWN_APIKEY tests", () => {
     
         test(`assert the received EventName is "REGISTER_VIEWER_ACK" within ${connectTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "5678"
                 }
             );
             await new Promise( resolve => {
                 Connection.onmessage = (event: MessageEvent) => {
-                    expect(event.data.byteLength).toBeGreaterThan(40);
-                    
-                    const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
-                    expect(eventName).toBe("REGISTER_VIEWER_ACK");
+                    const eventHeader16 = new Uint16Array(event.data, 0, 2);
+                    const eventType = eventHeader16[0];
+                    expect(event.data.byteLength).toBeGreaterThan(0);
+                    expect(eventType).toEqual(Utility.EventType.RegisterViewerAck);
     
                     resolve();
                 };
@@ -45,14 +45,14 @@ describe("ACCESS_CARTA_UNKNOWN_APIKEY tests", () => {
                
         test(`assert the "REGISTER_VIEWER_ACK.success" is true.`,
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "5678"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();
@@ -63,14 +63,14 @@ describe("ACCESS_CARTA_UNKNOWN_APIKEY tests", () => {
     
         test(`assert the "REGISTER_VIEWER_ACK.message" is empty.`,
         async () => {
-            await Utility.setEvent(Connection, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(Connection, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "5678"
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(Connection, CARTA.RegisterViewerAck, 
                     (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                         expect(RegisterViewerAck.message).toBeDefined();
                         expect(RegisterViewerAck.message).toEqual("");

--- a/src/test/ANIMATOR_NAVIGATION.test.ts
+++ b/src/test/ANIMATOR_NAVIGATION.test.ts
@@ -23,27 +23,27 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -64,7 +64,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
             
             test(`assert file name ${testFileName} with file id: ${fileId} ready.`, 
             async () => {
-                await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                await Utility.setEvent(Connection, CARTA.OpenFile, 
                     {
                         directory: baseDirectory + "/" + testSubdirectoryName, 
                         file: testFileName, 
@@ -74,7 +74,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                    Utility.getEvent(Connection, CARTA.OpenFileAck, 
                         OpenFileAck => {
                             expect(OpenFileAck.success).toBe(true);
                             resolve();
@@ -82,7 +82,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
                     );
                     
                 });
-                await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                await Utility.setEvent(Connection, CARTA.SetImageView, 
                     {
                         fileId, 
                         imageBounds: {
@@ -98,7 +98,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                    Utility.getEvent(Connection, CARTA.RasterImageData, 
                         RasterImageData => {
                             expect(RasterImageData.fileId).toEqual(fileId);
                             resolve();
@@ -111,7 +111,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
 
     test(`assert image channel to be 0 on file ID 0.`, 
     async () => {
-        await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels, 
+        await Utility.setEvent(Connection, CARTA.SetImageChannels, 
             {
                 fileId: 0, 
                 channel: 1, 
@@ -119,7 +119,7 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
             }
         );
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+            Utility.getEvent(Connection, CARTA.RasterImageData, 
                 RasterImageData => {
                     expect(RasterImageData.fileId).toEqual(0);
                     expect(RasterImageData.channel).toEqual(1);
@@ -134,14 +134,14 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
 
     test(`assert image channel to be 100 on file ID 1.`, 
     async () => {
-        await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels, 
+        await Utility.setEvent(Connection, CARTA.SetImageChannels, 
             {
                 fileId: 1, 
                 channel: 100,
             }
         );
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+            Utility.getEvent(Connection, CARTA.RasterImageData, 
                 RasterImageData => {
                     expect(RasterImageData.fileId).toEqual(1);
                     expect(RasterImageData.channel).toEqual(100);
@@ -171,27 +171,27 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -212,7 +212,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
             
             test(`assert file name ${testFileName} with file id: ${fileId} ready.`, 
             async () => { 
-                await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                await Utility.setEvent(Connection, CARTA.OpenFile, 
                     {
                         directory: baseDirectory + "/" + testSubdirectoryName, 
                         file: testFileName, 
@@ -222,7 +222,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                    Utility.getEvent(Connection, CARTA.OpenFileAck, 
                         OpenFileAck => {
                             expect(OpenFileAck.success).toBe(true);
                             resolve();
@@ -230,7 +230,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
                     );
                     
                 });
-                await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                await Utility.setEvent(Connection, CARTA.SetImageView, 
                     {
                         fileId, 
                         imageBounds: {
@@ -246,7 +246,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                    Utility.getEvent(Connection, CARTA.RasterImageData, 
                         RasterImageData => {
                             expect(RasterImageData.fileId).toEqual(fileId);
                             resolve();
@@ -260,7 +260,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
 
     test(`assert no returning message (image channel: 1000 & stokes: 3 on file ID 0).`, 
     async () => {
-        await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels, 
+        await Utility.setEvent(Connection, CARTA.SetImageChannels, 
             {
                 fileId: 0, 
                 channel: 100, 
@@ -281,7 +281,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
 
     test(`assert no returning message (image channel: 3000 & stokes: 1 on file ID 1).`, 
     async () => { 
-        await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels, 
+        await Utility.setEvent(Connection, CARTA.SetImageChannels, 
             {
                 fileId: 1, 
                 channel: 3000, 
@@ -302,7 +302,7 @@ describe("ANIMATOR_NAVIGATION_ERROR test: Testing error handle of animator",
 
     test(`assert no returning message (image channel: 0 & stokes: 0 on file ID 2).`, 
     async () => {
-        await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels, 
+        await Utility.setEvent(Connection, CARTA.SetImageChannels, 
             {
                 fileId: 2, 
                 channel: 0, 

--- a/src/test/ANIMATOR_PLAYBACK.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK.test.ts
@@ -22,27 +22,27 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -50,7 +50,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                     }
                 );                
             });
-            await Utility.setEvent(this, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(this, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -60,7 +60,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(this, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         resolve();
@@ -68,7 +68,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 );
                 
             });
-            await Utility.setEvent(this, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(this, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -82,7 +82,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(this, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.fileId).toEqual(0);
                         resolve();
@@ -99,7 +99,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
     async () => {
         timer = await new Date().getTime();
         for (let idx = 1; idx < playFrames + 1; idx++) {
-            await Utility.setEvent(Connection, "SET_IMAGE_CHANNELS", CARTA.SetImageChannels,  
+            await Utility.setEvent(Connection, CARTA.SetImageChannels,  
                 {
                     fileId: 0, 
                     channel: idx, 
@@ -107,7 +107,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 }
             );
             await new Promise( (resolve, reject) => {
-                Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(Connection, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.fileId).toEqual(0);
                         expect(RasterImageData.channel).toEqual(idx);

--- a/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
+++ b/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
@@ -21,27 +21,27 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -58,7 +58,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
         
         test(`assert the file "${testFileName}" info be able to read.`, 
         async done => {
-            await Utility.setEvent(Connection, "FILE_INFO_REQUEST", CARTA.FileInfoRequest, 
+            await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -66,7 +66,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                 }
             ); 
             await new Promise( resolve => {           
-                Utility.getEvent(Connection, "FILE_INFO_RESPONSE", CARTA.FileInfoResponse, 
+                Utility.getEvent(Connection, CARTA.FileInfoResponse, 
                     FileInfoResponse => {
                         expect(FileInfoResponse.success).toBe(true);
                         resolve();
@@ -78,7 +78,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
         test(`assert the file "${testFileName}" be able to open.`, 
         async done => {
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -88,7 +88,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         resolve();
@@ -100,7 +100,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
         test(`assert the file "${testFileName}" image be able to read.`, 
         async done => {
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -111,7 +111,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
             );
             let OpenFileAckTemp: CARTA.OpenFileAck;
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         OpenFileAckTemp = OpenFileAck;
@@ -119,7 +119,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                     }
                 );                
             });
-            await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(Connection, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -133,7 +133,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(Connection, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.fileId).toEqual(0);
                         resolve();
@@ -149,7 +149,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
         let OpenFileAckTemp: CARTA.OpenFileAck;
         beforeEach( 
         async done => {
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -159,7 +159,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         OpenFileAckTemp = OpenFileAck;
@@ -209,7 +209,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
     () => {
         beforeEach( 
         async done => { 
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -219,7 +219,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         resolve();
@@ -244,7 +244,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                     
                     test(`assert the file returns correct image info.`, 
                     async done => {
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId, 
                                 imageBounds, 
@@ -255,7 +255,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     expect(RasterImageData.fileId).toEqual(fileId);
                                     expect(RasterImageData.imageBounds).toEqual({xMax: imageBounds.xMax, yMax: imageBounds.yMax});
@@ -275,7 +275,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
                     test(`assert channel histogram data.`, 
                     async done => {
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId, 
                                 imageBounds, 
@@ -286,7 +286,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     let channelHistogram = RasterImageData.channelHistogramData.histograms[0];
                                     expect(channelHistogram.numBins).toEqual(numBins);
@@ -307,7 +307,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
                     test(`assert nan_encodings is empty.`, 
                     async done => {
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId, 
                                 imageBounds, 
@@ -318,7 +318,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     let nanEncodings = RasterImageData.nanEncodings;
                                     if (compressionType === CARTA.CompressionType.NONE) {
@@ -335,7 +335,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
 
                     test(`assert data value at position (${assertPoint1.point.x}, ${assertPoint1.point.y}) & (${assertPoint2.point.x}, ${assertPoint2.point.y}).`, 
                     async done => {
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId, 
                                 imageBounds, 
@@ -346,7 +346,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     let imageData = RasterImageData.imageData;
                                     let imageDataSum = 0;

--- a/src/test/CURSOR_XY_PROFILE.test.ts
+++ b/src/test/CURSOR_XY_PROFILE.test.ts
@@ -20,27 +20,27 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -54,7 +54,7 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
 
     describe(`open the file "${testFileName}" to`, () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -65,7 +65,7 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
             );
             let OpenFileAckTemp: CARTA.OpenFileAck; 
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         OpenFileAckTemp = OpenFileAck;
@@ -73,7 +73,7 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
                     }
                 );                
             });
-            await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(Connection, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -86,7 +86,7 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
                     numSubsets: 4
                 }
             );
-            await Utility.setEvent(Connection, "SET_SPATIAL_REQUIREMENTS", CARTA.SetSpatialRequirements, 
+            await Utility.setEvent(Connection, CARTA.SetSpatialRequirements, 
                 {
                     fileId: 0, 
                     regionId: 0, 
@@ -94,7 +94,7 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(Connection, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.imageData.length).toBeGreaterThan(0);
                         resolve();
@@ -120,14 +120,14 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
                     
                     test(`assert the fileID "${fileId}" returns: Value=${value}, Profile length={${profileLen.x}, ${profileLen.y}}, Point={${assertPoint.x}, ${assertPoint.y}} as {${point.x}, ${point.y}}.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "SET_CURSOR", CARTA.SetCursor, 
+                        await Utility.setEvent(Connection, CARTA.SetCursor, 
                             {
                                 fileId, 
                                 point,
                             }
                         );
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "SPATIAL_PROFILE_DATA", CARTA.SpatialProfileData, 
+                            Utility.getEvent(Connection, CARTA.SpatialProfileData, 
                                 SpatialProfileData => {
                                     expect(SpatialProfileData.fileId).toEqual(fileId);
                                     expect(SpatialProfileData.value).toEqual(value);
@@ -162,14 +162,14 @@ describe("CURSOR_XY_PROFILE test: Testing if full resolution cursor xy profiles 
                     the #${oddPointX.idx + 1} value = ${oddPointX.value} with other values = ${oddPointX.others} on the profile_x & 
                     the #${oddPointY.idx + 1} value = ${oddPointY.value} with other values = ${oddPointY.others} on the profile_y as point {${point.x}, ${point.y}}.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "SET_CURSOR", CARTA.SetCursor, 
+                        await Utility.setEvent(Connection, CARTA.SetCursor, 
                             {
                                 fileId, 
                                 point,
                             }
                         ); 
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "SPATIAL_PROFILE_DATA", CARTA.SpatialProfileData, 
+                            Utility.getEvent(Connection, CARTA.SpatialProfileData, 
                                 SpatialProfileData => {
                                     // Assert profile x
                                     SpatialProfileData.profiles.find(f => f.coordinate === "x").values.forEach( 

--- a/src/test/CURSOR_XY_PROFILE_PERFORMANCE.test.ts
+++ b/src/test/CURSOR_XY_PROFILE_PERFORMANCE.test.ts
@@ -22,27 +22,27 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -84,7 +84,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                     let timer: number;
                     test(`set a random cursor at round ${idx + 1} on image "${testFileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                        await Utility.setEvent(Connection, CARTA.OpenFile, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: testFileName, 
@@ -95,7 +95,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                         );
                         let OpenFileAckTemp: CARTA.OpenFileAck; 
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                            Utility.getEvent(Connection, CARTA.OpenFileAck, 
                                 OpenFileAck => {
                                     expect(OpenFileAck.success).toBe(true);
                                     OpenFileAckTemp = OpenFileAck;
@@ -103,7 +103,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                                 }
                             );                
                         });
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId: 0, 
                                 imageBounds: {
@@ -116,7 +116,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                                 numSubsets,
                             }
                         );
-                        await Utility.setEvent(Connection, "SET_SPATIAL_REQUIREMENTS", CARTA.SetSpatialRequirements, 
+                        await Utility.setEvent(Connection, CARTA.SetSpatialRequirements, 
                             {
                                 fileId: 0, 
                                 regionId: 0, 
@@ -125,7 +125,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                         );
                         let RasterImageDataTemp: CARTA.RasterImageData;
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     expect(RasterImageData.imageData.length).toBeGreaterThan(0);
                                     RasterImageDataTemp = RasterImageData;
@@ -134,7 +134,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                             );                
                         });
                         timer = await new Date().getTime();
-                        await Utility.setEvent(Connection, "SET_CURSOR", CARTA.SetCursor, 
+                        await Utility.setEvent(Connection, CARTA.SetCursor, 
                             {
                                 fileId: 0, 
                                 point: {
@@ -144,7 +144,7 @@ describe("CURSOR_XY_PROFILE_PERFORMANCE test: Testing the performance of cursor 
                             }
                         );
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "SPATIAL_PROFILE_DATA", CARTA.SpatialProfileData, 
+                            Utility.getEvent(Connection, CARTA.SpatialProfileData, 
                                 SpatialProfileData => {
                                     expect(SpatialProfileData.profiles.length).not.toEqual(0); 
                                     resolve();

--- a/src/test/CURSOR_Z_PROFILE.test.ts
+++ b/src/test/CURSOR_Z_PROFILE.test.ts
@@ -20,27 +20,27 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -55,7 +55,7 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
     describe(`open the file "${testFileName} to `, 
     () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(Connection, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -66,7 +66,7 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
             );
             let OpenFileAckTemp: CARTA.OpenFileAck; 
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(Connection, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         OpenFileAckTemp = OpenFileAck;
@@ -74,7 +74,7 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
                     }
                 );                
             });
-            await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(Connection, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -87,7 +87,7 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
                     numSubsets: 4
                 }
             );
-            await Utility.setEvent(Connection, "SET_SPECTRAL_REQUIREMENTS", CARTA.SetSpectralRequirements,  
+            await Utility.setEvent(Connection, CARTA.SetSpectralRequirements,  
                 {
                     fileId: 0, 
                     regionId: 0, 
@@ -95,7 +95,7 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(Connection, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.imageData.length).toBeGreaterThan(0);
                         resolve();
@@ -114,14 +114,14 @@ describe("CURSOR_Z_PROFILE test: Testing if full resolution cursor z profile is 
                     let SpectralProfileDataTemp: CARTA.SpectralProfileData;
                     test(`assert the fileId "${fileId}" returns within ${connectionTimeout}ms, as point {${point.x}, ${point.y}}.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "SET_CURSOR", CARTA.SetCursor, 
+                        await Utility.setEvent(Connection, CARTA.SetCursor, 
                             {
                                 fileId, 
                                 point,
                             }
                         );  
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "SPECTRAL_PROFILE_DATA", CARTA.SpectralProfileData, 
+                            Utility.getEvent(Connection, CARTA.SpectralProfileData, 
                                 SpectralProfileData => {
                                     SpectralProfileDataTemp = SpectralProfileData;
                                     resolve();

--- a/src/test/CURSOR_Z_PROFILE_PERFORMANCE.test.ts
+++ b/src/test/CURSOR_Z_PROFILE_PERFORMANCE.test.ts
@@ -22,14 +22,14 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
@@ -81,7 +81,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                     let timer: number;
                     test(`set a random cursor at round ${idx + 1} on the file "${testFileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                        await Utility.setEvent(Connection, CARTA.OpenFile, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: testFileName, 
@@ -92,7 +92,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                         );
                         let OpenFileAckTemp: CARTA.OpenFileAck; 
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                            Utility.getEvent(Connection, CARTA.OpenFileAck, 
                                 OpenFileAck => {
                                     expect(OpenFileAck.success).toBe(true);
                                     OpenFileAckTemp = OpenFileAck;
@@ -100,7 +100,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                                 }
                             );                
                         });
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId: 0, 
                                 imageBounds: {
@@ -113,7 +113,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                                 numSubsets,
                             }
                         );
-                        await Utility.setEvent(Connection, "SET_SPECTRAL_REQUIREMENTS", CARTA.SetSpectralRequirements, 
+                        await Utility.setEvent(Connection, CARTA.SetSpectralRequirements, 
                             {
                                 fileId: 0, 
                                 regionId: 0, 
@@ -127,7 +127,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                         );
                         let RasterImageDataTemp: CARTA.RasterImageData;
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     expect(RasterImageData.imageData.length).toBeGreaterThan(0);
                                     RasterImageDataTemp = RasterImageData;
@@ -136,7 +136,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                             );                
                         });
                         timer = await new Date().getTime();
-                        await Utility.setEvent(Connection, "SET_CURSOR", CARTA.SetCursor, 
+                        await Utility.setEvent(Connection, CARTA.SetCursor, 
                             {
                                 fileId: 0, 
                                 point: {
@@ -146,7 +146,7 @@ describe("CURSOR_Z_PROFILE_PERFORMANCE test: Testing the performance of cursor z
                             }
                         );
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "SPECTRAL_PROFILE_DATA", CARTA.SpectralProfileData, 
+                            Utility.getEvent(Connection, CARTA.SpectralProfileData, 
                                     SpectralProfileData => {
                                     expect(SpectralProfileData.profiles.length).not.toEqual(0); 
                                     resolve();

--- a/src/test/FILEINFO.test.ts
+++ b/src/test/FILEINFO.test.ts
@@ -19,14 +19,14 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234",
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
@@ -46,13 +46,13 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
             ([dir]) => {
                 test(`open the directory "${dir}".`, 
                 async () => {
-                    await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                    await Utility.setEvent(Connection, CARTA.FileListRequest, 
                         {
                             directory: dir,
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                        Utility.getEvent(Connection, CARTA.FileListResponse, 
                             FileListResponseBase => {
                                 expect(FileListResponseBase.success).toBe(true);
                                 resolve();
@@ -69,13 +69,13 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
         let baseDirectory: string; 
         beforeEach( 
             async () => {
-                await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                await Utility.setEvent(Connection, CARTA.FileListRequest, 
                     {
                         directory: expectBasePath,
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                    Utility.getEvent(Connection, CARTA.FileListResponse, 
                         FileListResponseBase => {
                             expect(FileListResponseBase.success).toBe(true);
                             baseDirectory = FileListResponseBase.directory;
@@ -83,13 +83,13 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
                         }
                     );                
                 });
-                await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                await Utility.setEvent(Connection, CARTA.FileListRequest, 
                     {
                         directory: baseDirectory,
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                    Utility.getEvent(Connection, CARTA.FileListResponse, 
                         FileListResponseBase => {
                             expect(FileListResponseBase.success).toBe(true);
                             resolve();
@@ -110,7 +110,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
                          [string,   string, number,     CARTA.FileType, number[],   number]) {
                     test(`assert the info of ${CARTA.FileType[fileType]} file "${fileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_INFO_REQUEST", CARTA.FileInfoRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: fileName, 
@@ -118,7 +118,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_INFO_RESPONSE", CARTA.FileInfoResponse, 
+                            Utility.getEvent(Connection, CARTA.FileInfoResponse, 
                                 (FileInfoResponse: CARTA.FileInfoResponse) => {
                                     expect(FileInfoResponse.success).toBe(true);
                                     expect(FileInfoResponse.fileInfo.HDUList.find( f => f === hdu)).toEqual(hdu);
@@ -133,7 +133,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
 
                     test(`assert the extended info of ${CARTA.FileType[fileType]} file "${fileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_INFO_REQUEST", CARTA.FileInfoRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: fileName, 
@@ -141,7 +141,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_INFO_RESPONSE", CARTA.FileInfoResponse, 
+                            Utility.getEvent(Connection, CARTA.FileInfoResponse, 
                                 (FileInfoResponse: CARTA.FileInfoResponse) => {                                    
                                     expect(FileInfoResponse.fileInfoExtended.dimensions).toEqual(NAXIS);
                                     expect(FileInfoResponse.fileInfoExtended.width).toEqual(shape[0]);
@@ -168,7 +168,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
 
                     test(`assert the header info of ${CARTA.FileType[fileType]} file "${fileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_INFO_REQUEST", CARTA.FileInfoRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: fileName, 
@@ -176,7 +176,7 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_INFO_RESPONSE", CARTA.FileInfoResponse, 
+                            Utility.getEvent(Connection, CARTA.FileInfoResponse, 
                                 (FileInfoResponse: CARTA.FileInfoResponse) => {                                    
                                     const fileInfoExtHeaderNAXIS = 
                                         FileInfoResponse.fileInfoExtended.headerEntries.find( f => f.name === "NAXIS").value;
@@ -224,14 +224,14 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
@@ -247,13 +247,13 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
         let baseDirectory: string; 
         beforeEach(
             async () => {
-                await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                await Utility.setEvent(Connection, CARTA.FileListRequest, 
                     {
                         directory: expectBasePath
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                    Utility.getEvent(Connection, CARTA.FileListResponse, 
                         FileListResponseBase => {
                             expect(FileListResponseBase.success).toBe(true);
                             baseDirectory = FileListResponseBase.directory;
@@ -261,13 +261,13 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
                         }
                     );                
                 });
-                await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                await Utility.setEvent(Connection, CARTA.FileListRequest, 
                     {
                         directory: baseDirectory
                     }
                 );
                 await new Promise( resolve => {
-                    Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                    Utility.getEvent(Connection, CARTA.FileListResponse, 
                         FileListResponseBase => {
                             expect(FileListResponseBase.success).toBe(true);
                             resolve();
@@ -284,7 +284,7 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
                 function([fileName]: [string]) {
                     test(`assert the file "${fileName}" is non-existent.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_INFO_REQUEST", CARTA.FileInfoRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: fileName, 
@@ -292,7 +292,7 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
                             }
                         );
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "FILE_INFO_RESPONSE", CARTA.FileInfoResponse, 
+                            Utility.getEvent(Connection, CARTA.FileInfoResponse, 
                                 (FileInfoResponse: CARTA.FileInfoResponse) => {
                                     expect(FileInfoResponse.success).toBe(false);
                                     expect(FileInfoResponse.message).toBeDefined();

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -18,14 +18,14 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
@@ -39,13 +39,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
     let baseDirectory: string;
     test(`assert the base path.`,      
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         expect(FileListResponse.success).toBe(true);
                         baseDirectory = FileListResponse.directory;
@@ -59,13 +59,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
     () => {
         test(`assert the received EventName is "FILE_LIST_RESPONSE" within ${connectionTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         resolve();
                     }
@@ -75,13 +75,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
     
         test(`assert the "FILE_LIST_RESPONSE.success" is true.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.success).toBe(true);
                         resolve();
@@ -92,13 +92,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
 
         test(`assert the "FILE_LIST_RESPONSE.parent" is "$BASE".`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.parent).toBe(baseDirectory);
                         resolve();
@@ -109,13 +109,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
 
         test(`assert the "FILE_LIST_RESPONSE.directory" is the path "$BASE/${testSubdirectoryName}".`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.directory).toBe(baseDirectory === expectRootPath ? testSubdirectoryName : baseDirectory + "/" + testSubdirectoryName);
                         resolve();
@@ -137,13 +137,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
     
                     test(`assert the file "${file}" exists, image type is ${CARTA.FileType[type]}, size = ${size}, HDU = [${hdu}].`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileListRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName,
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                            Utility.getEvent(Connection, CARTA.FileListResponse, 
                                 (FileListResponse: CARTA.FileListResponse) => {
                                     expect(FileListResponse.success).toBe(true);
     
@@ -171,13 +171,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
                 function([file]: [string]) {
                     test(`assert the file "${file}" does not exist.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileListRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName,
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                            Utility.getEvent(Connection, CARTA.FileListResponse, 
                                 (FileListResponse: CARTA.FileListResponse) => {
                                     expect(FileListResponse.success).toBe(true);
                                     let fileInfo = FileListResponse.files.find(f => f.name === file);
@@ -199,13 +199,13 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
                 ([folder]) => {
                     test(`assert the folder "${folder}" exists.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+                        await Utility.setEvent(Connection, CARTA.FileListRequest, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName,
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                            Utility.getEvent(Connection, CARTA.FileListResponse, 
                                 (FileListResponse: CARTA.FileListResponse) => {
                                     expect(FileListResponse.success).toBe(true);
                                     let folderInfo = FileListResponse.subdirectories.find(f => f === folder);

--- a/src/test/GET_FILELIST.test.ts
+++ b/src/test/GET_FILELIST.test.ts
@@ -24,14 +24,14 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
             Connection.onopen = OnOpen;
             async function OnOpen (this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
-                await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+                await Utility.setEvent(this, CARTA.RegisterViewer, 
                     {
-                        sessionId: "", 
+                        sessionId: 0, 
                         apiKey: "1234",
                     }
                 );
                 await new Promise( resolve => { 
-                    Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                    Utility.getEvent(this, CARTA.RegisterViewerAck, 
                         RegisterViewerAck => {
                             expect(RegisterViewerAck.success).toBe(true);
                             resolve();           
@@ -44,13 +44,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
     
         test(`assert the "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectRootPath,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         resolve();
                     }
@@ -60,13 +60,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
     
         test(`assert the "FILE_LIST_RESPONSE.success" is true.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectRootPath,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.success).toBe(true);
                         resolve();
@@ -77,13 +77,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
 
         test(`assert the "FILE_LIST_RESPONSE.parent" is "" .`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectRootPath,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.parent).toBe("");
                         resolve();
@@ -94,13 +94,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
 
         test(`assert the "FILE_LIST_RESPONSE.directory" is root path "${expectRootPath}".`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectRootPath,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.directory).toBe(expectRootPath);
                         resolve();
@@ -111,13 +111,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
 
         test(`assert the base path.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -129,13 +129,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
 
         test(`assert the file "${testFileName}" exists.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         let fileInfo = FileListResponse.files.find(f => f.name === testFileName);
                         expect(fileInfo).toBeDefined();
@@ -148,13 +148,13 @@ describe("GET_FILELIST_ROOTPATH tests: Testing generation of a file list at root
     
         test(`assert the subdirectory "${testSubdirectoryName}" exists.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: baseDirectory,
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         let folderInfo = FileListResponse.subdirectories.find(f => f === testSubdirectoryName);
                         expect(folderInfo).toBeDefined();
@@ -184,14 +184,14 @@ describe("GET_FILELIST_UNKNOWNPATH tests: Testing error handle of file list gene
             Connection.onopen = OnOpen;
             async function OnOpen (this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
-                await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+                await Utility.setEvent(this, CARTA.RegisterViewer, 
                     {
-                        sessionId: "", 
+                        sessionId: 0, 
                         apiKey: "1234",
                     }
                 );
                 await new Promise( resolve => { 
-                    Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                    Utility.getEvent(this, CARTA.RegisterViewerAck, 
                         RegisterViewerAck => {
                             expect(RegisterViewerAck.success).toBe(true);
                             resolve();           
@@ -204,13 +204,13 @@ describe("GET_FILELIST_UNKNOWNPATH tests: Testing error handle of file list gene
     
         test(`assert the "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: "/unknown/path",
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     FileListResponse => {
                         resolve();
                     }
@@ -220,13 +220,13 @@ describe("GET_FILELIST_UNKNOWNPATH tests: Testing error handle of file list gene
     
         test(`assert the "FILE_LIST_RESPONSE.success" is false.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: "/unknown/path",
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.success).toBe(false);
                         resolve();
@@ -237,13 +237,13 @@ describe("GET_FILELIST_UNKNOWNPATH tests: Testing error handle of file list gene
 
         test(`assert the "FILE_LIST_RESPONSE.message" is not empty.`, 
         async () => {
-            await Utility.setEvent(Connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(Connection, CARTA.FileListRequest, 
                 {
                     directory: "/unknown/path",
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(Connection, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection, CARTA.FileListResponse, 
                     (FileListResponse: CARTA.FileListResponse) => {
                         expect(FileListResponse.message).toBeDefined();
                         expect(FileListResponse.message).not.toEqual("");

--- a/src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts
+++ b/src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts
@@ -22,14 +22,14 @@ describe("GET_FILELIST_ROOTPATH_CONCURRENT test: Testing generation of a file li
             promiseConn[idx] = new Promise( (resolved, reject) => {
                 Connection[idx].onopen = async () => {
                     expect(Connection[idx].readyState).toBe(WebSocket.OPEN);
-                    await Utility.setEvent(Connection[idx], "REGISTER_VIEWER", CARTA.RegisterViewer, 
+                    await Utility.setEvent(Connection[idx], CARTA.RegisterViewer, 
                         {
-                            sessionId: "", 
+                            sessionId: 0, 
                             apiKey: "1234"
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection[idx], "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                        Utility.getEvent(Connection[idx], CARTA.RegisterViewerAck, 
                             (RegisterViewerAck: CARTA.RegisterViewerAck) => {
                                 expect(RegisterViewerAck.success).toBe(true);
                                 resolve();
@@ -50,7 +50,7 @@ describe("GET_FILELIST_ROOTPATH_CONCURRENT test: Testing generation of a file li
         let promiseConnection: Promise<void>[] = new Array(testNumber);
         for (let idx = 0; idx < testNumber; idx++) {
             promiseConnection[idx] = new Promise( (resolve, reject) => {
-                Utility.getEvent(Connection[idx], "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(Connection[idx], CARTA.FileListResponse, 
                     FileListResponse => {
                         expect(FileListResponse.success).toBe(true);
                         fileListResponse[idx] = FileListResponse;
@@ -66,7 +66,7 @@ describe("GET_FILELIST_ROOTPATH_CONCURRENT test: Testing generation of a file li
         Promise.all(promiseConnection).then( () => done() );
         
         for (let connection of Connection) {
-            Utility.setEvent(connection, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            Utility.setEvent(connection, CARTA.FileListRequest, 
                 {
                     directory: expectRootPath
                 }

--- a/src/test/OPEN_IMAGE_MULTIFRAME.test.ts
+++ b/src/test/OPEN_IMAGE_MULTIFRAME.test.ts
@@ -21,27 +21,27 @@ describe("OPEN_IMAGE_MULTIFRAME test: Testing the case of opening multiple image
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -68,7 +68,7 @@ describe("OPEN_IMAGE_MULTIFRAME test: Testing the case of opening multiple image
 
                     test(`assert to open the file "${testFileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                        await Utility.setEvent(Connection, CARTA.OpenFile, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: testFileName, 
@@ -78,7 +78,7 @@ describe("OPEN_IMAGE_MULTIFRAME test: Testing the case of opening multiple image
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                            Utility.getEvent(Connection, CARTA.OpenFileAck, 
                                 OpenFileAck => {
                                     expect(OpenFileAck.success).toBe(true);
                                     expect(OpenFileAck.fileId).toEqual(fileId);
@@ -91,7 +91,7 @@ describe("OPEN_IMAGE_MULTIFRAME test: Testing the case of opening multiple image
                     
                     test(`assert the file ID of "${testFileName}" to be ${fileId}.`, 
                     async () => {
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId, 
                                 imageBounds: {
@@ -105,7 +105,7 @@ describe("OPEN_IMAGE_MULTIFRAME test: Testing the case of opening multiple image
                             }
                         );
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     expect(RasterImageData.fileId).toEqual(fileId);
                                     resolve();

--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -22,27 +22,27 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -64,7 +64,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                 
                 test(`assert file "${testFileName}" to be ready.`, 
                 async () => {
-                    await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                    await Utility.setEvent(Connection, CARTA.OpenFile, 
                         {
                             directory: baseDirectory + "/" + testSubdirectoryName, 
                             file: testFileName, 
@@ -74,7 +74,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                        Utility.getEvent(Connection, CARTA.OpenFileAck, 
                             OpenFileAck => {
                                 expect(OpenFileAck.success).toBe(true);
                                 resolve();
@@ -82,7 +82,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                         );
                         
                     });
-                    await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                    await Utility.setEvent(Connection, CARTA.SetImageView, 
                         {
                             fileId, 
                             imageBounds: {
@@ -96,7 +96,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                        Utility.getEvent(Connection, CARTA.RasterImageData, 
                             RasterImageData => {
                                 expect(RasterImageData.fileId).toEqual(fileId);
                                 resolve();
@@ -108,7 +108,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                 let regionHistogramProgress: number;
                 test(`assert the first REGION_HISTOGRAM_DATA arrives.`, 
                 async () => {
-                    await Utility.setEvent(Connection, "SET_HISTOGRAM_REQUIREMENTS", CARTA.SetHistogramRequirements, 
+                    await Utility.setEvent(Connection, CARTA.SetHistogramRequirements, 
                         {
                             fileId, 
                             regionId: -2, 
@@ -116,7 +116,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                         }
                     );
                     await new Promise( resolve => { 
-                        Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                        Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                             RegionHistogramData => {
                                 regionHistogramProgress = RegionHistogramData.progress;
                                 console.log(`Region Histogram Progress = ${regionHistogramProgress}`);                                
@@ -131,7 +131,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                 test(`assert the second REGION_HISTOGRAM_DATA arrives.`, 
                 async () => {
                     await new Promise( resolve => {                        
-                        Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                        Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                             RegionHistogramData => {
                                 expect(RegionHistogramData.progress).toBeGreaterThan(regionHistogramProgress);
                                 regionHistogramProgress = RegionHistogramData.progress;
@@ -147,7 +147,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                     expect(regionHistogramProgress).toBeLessThan(1.0);
                     while (regionHistogramProgress < 0.5) {
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                            Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                                 (RegionHistogramData: CARTA.RegionHistogramData) => {
                                     regionHistogramProgress = RegionHistogramData.progress;
                                     console.log(`Region Histogram Progress = ${regionHistogramProgress}`);
@@ -158,7 +158,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                     }
                     if (regionHistogramProgress < 1.0) {
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                            Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                                 (RegionHistogramData: CARTA.RegionHistogramData) => {
                                     regionHistogramProgress = RegionHistogramData.progress;
                                     console.log(`Region Histogram Progress = ${regionHistogramProgress}`);
@@ -180,7 +180,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                     expect(regionHistogramProgress).not.toEqual(1.0);
                     while (regionHistogramProgress < 1.0) {
                         await new Promise( resolve => {                        
-                            Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                            Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                                 (RegionHistogramData: CARTA.RegionHistogramData) => {
                                     regionHistogramProgress = RegionHistogramData.progress;
                                     console.log(`Region Histogram Progress = ${regionHistogramProgress}`);

--- a/src/test/PER_CUBE_HISTOGRAM_CANCEL.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCEL.test.ts
@@ -24,27 +24,27 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -66,7 +66,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                 
                 test(`assert file "${testFileName}" to be ready.`, 
                 async () => {
-                    await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                    await Utility.setEvent(Connection, CARTA.OpenFile, 
                         {
                             directory: baseDirectory + "/" + testSubdirectoryName, 
                             file: testFileName, 
@@ -76,7 +76,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                        Utility.getEvent(Connection, CARTA.OpenFileAck, 
                             OpenFileAck => {
                                 expect(OpenFileAck.success).toBe(true);
                                 resolve();
@@ -84,7 +84,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                         );
                         
                     });
-                    await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                    await Utility.setEvent(Connection, CARTA.SetImageView, 
                         {
                             fileId, 
                             imageBounds: {
@@ -98,7 +98,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                         }
                     );
                     await new Promise( resolve => {
-                        Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                        Utility.getEvent(Connection, CARTA.RasterImageData, 
                             RasterImageData => {
                                 expect(RasterImageData.fileId).toEqual(fileId);
                                 resolve();
@@ -110,7 +110,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                 let regionHistogramProgress: number;
                 test(`assert the first REGION_HISTOGRAM_DATA arrives.`, 
                 async () => {
-                    await Utility.setEvent(Connection, "SET_HISTOGRAM_REQUIREMENTS", CARTA.SetHistogramRequirements, 
+                    await Utility.setEvent(Connection, CARTA.SetHistogramRequirements, 
                         {
                             fileId, 
                             regionId: -2, 
@@ -118,7 +118,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                         }
                     );
                     await new Promise( resolve => { 
-                        Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                        Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                             RegionHistogramData => {
                                 regionHistogramProgress = RegionHistogramData.progress;
                                 console.log(`Region Histogram Progress = ${regionHistogramProgress}`);                                
@@ -133,7 +133,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                 test(`assert the second REGION_HISTOGRAM_DATA arrives.`, 
                 async () => {
                     await new Promise( resolve => {                        
-                        Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                        Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                             RegionHistogramData => {
                                 expect(RegionHistogramData.progress).toBeGreaterThan(regionHistogramProgress);
                                 regionHistogramProgress = RegionHistogramData.progress;
@@ -152,7 +152,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                             resolve();
                         }, cancelTimeout);
                     });
-                    await Utility.setEvent(Connection, "SET_HISTOGRAM_REQUIREMENTS", CARTA.SetHistogramRequirements, 
+                    await Utility.setEvent(Connection, CARTA.SetHistogramRequirements, 
                         {
                             fileId, 
                             regionId: -2, 
@@ -180,7 +180,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                             resolve();
                         }, 2000);
                     });
-                    await Utility.setEvent(Connection, "SET_HISTOGRAM_REQUIREMENTS", CARTA.SetHistogramRequirements, 
+                    await Utility.setEvent(Connection, CARTA.SetHistogramRequirements, 
                         {
                             fileId, 
                             regionId: -2, 
@@ -189,7 +189,7 @@ describe("PER_CUBE_HISTOGRAM_CANCEL tests: Testing the cancellation capability o
                     ); 
                     while (regionHistogramProgress < 1.0) {
                         await new Promise( (resolve, reject) => {                        
-                            Utility.getEvent(Connection, "REGION_HISTOGRAM_DATA", CARTA.RegionHistogramData, 
+                            Utility.getEvent(Connection, CARTA.RegionHistogramData, 
                                 (RegionHistogramData: CARTA.RegionHistogramData) => {
                                     regionHistogramProgress = RegionHistogramData.progress;
                                     console.log(`Region Histogram Progress = ${regionHistogramProgress}`);

--- a/src/test/RASTER_IMAGE_DATA_PERFORMANCE.test.ts
+++ b/src/test/RASTER_IMAGE_DATA_PERFORMANCE.test.ts
@@ -21,27 +21,27 @@ describe("RASTER_IMAGE_DATA_PERFORMANCE test: Testing performance of the generat
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -65,8 +65,8 @@ describe("RASTER_IMAGE_DATA_PERFORMANCE test: Testing performance of the generat
                 [2,    "cluster_00512.fits",       {xMin: 0, xMax:   512, yMin: 0, yMax:   512},    2, CARTA.CompressionType.ZFP, 11, 4], 
                 [3,    "cluster_01024.fits",       {xMin: 0, xMax:  1024, yMin: 0, yMax:  1024},    3, CARTA.CompressionType.ZFP, 11, 4],
                 [4,    "cluster_02048.fits",       {xMin: 0, xMax:  2048, yMin: 0, yMax:  2048},    6, CARTA.CompressionType.ZFP, 11, 4],
-                [5,    "cluster_04096.fits",       {xMin: 0, xMax:  4096, yMin: 0, yMax:  4096},   12, CARTA.CompressionType.ZFP, 11, 4],  
-                [6,    "cluster_08192.fits",       {xMin: 0, xMax:  8192, yMin: 0, yMax:  8192},   23, CARTA.CompressionType.ZFP, 11, 4],
+                // [5,    "cluster_04096.fits",       {xMin: 0, xMax:  4096, yMin: 0, yMax:  4096},   12, CARTA.CompressionType.ZFP, 11, 4],  
+                // [6,    "cluster_08192.fits",       {xMin: 0, xMax:  8192, yMin: 0, yMax:  8192},   23, CARTA.CompressionType.ZFP, 11, 4],
                 // [7,    "cluster_16384.fits",       {xMin: 0, xMax: 16384, yMin: 0, yMax: 16384},   46, CARTA.CompressionType.ZFP, 11, 4],
                 // [8,    "cluster_32768.fits",       {xMin: 0, xMax: 32768, yMin: 0, yMax: 32768},   92, CARTA.CompressionType.ZFP, 11, 4],
                 // [9,    "hugeGaussian10k.fits",     {xMin: 0, xMax: 10000, yMin: 0, yMax: 10000},   28, CARTA.CompressionType.ZFP, 11, 4],
@@ -89,7 +89,7 @@ describe("RASTER_IMAGE_DATA_PERFORMANCE test: Testing performance of the generat
                     let timer: number;
                     test(`assert image be read at round ${idx + 1} on the file "${testFileName}".`, 
                     async () => {
-                        await Utility.setEvent(Connection, "OPEN_FILE", CARTA.OpenFile, 
+                        await Utility.setEvent(Connection, CARTA.OpenFile, 
                             {
                                 directory: baseDirectory + "/" + testSubdirectoryName, 
                                 file: testFileName, 
@@ -99,14 +99,14 @@ describe("RASTER_IMAGE_DATA_PERFORMANCE test: Testing performance of the generat
                             }
                         );
                         await new Promise( resolve => { 
-                            Utility.getEvent(Connection, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                            Utility.getEvent(Connection, CARTA.OpenFileAck, 
                                 OpenFileAck => {
                                     expect(OpenFileAck.success).toBe(true);
                                     resolve();
                                 }
                             );
                         });
-                        await Utility.setEvent(Connection, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+                        await Utility.setEvent(Connection, CARTA.SetImageView, 
                             {
                                 fileId: 0, 
                                 imageBounds: {
@@ -121,7 +121,7 @@ describe("RASTER_IMAGE_DATA_PERFORMANCE test: Testing performance of the generat
                         );
                         timer = await new Date().getTime();
                         await new Promise( resolve => {
-                            Utility.getEvent(Connection, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                            Utility.getEvent(Connection, CARTA.RasterImageData, 
                                 RasterImageData => {
                                     expect(RasterImageData.imageData.length).toBeGreaterThan(0);
                                     resolve();

--- a/src/test/REGION_SPECTRAL_PROFILE_DEV.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_DEV.test.ts
@@ -21,27 +21,27 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -49,7 +49,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
                     }
                 );                
             });
-            await Utility.setEvent(this, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(this, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -59,14 +59,14 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(this, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         resolve();
                     }
                 );                
             });
-            await Utility.setEvent(this, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(this, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -80,7 +80,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(this, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.fileId).toEqual(0);
                         resolve();
@@ -93,7 +93,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
 
     test(`Test to set a region.`, 
     async done => {
-        await Utility.setEvent(Connection, "SET_REGION", CARTA.SetRegion, 
+        await Utility.setEvent(Connection, CARTA.SetRegion, 
             {
                 fileId: 0, 
                 regionId: -1, 
@@ -107,7 +107,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
             }
         );
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "SET_REGION_ACK", CARTA.SetRegionAck, 
+            Utility.getEvent(Connection, CARTA.SetRegionAck, 
                 SetRegionAck => {
                     expect(SetRegionAck.success).toBe(true);
                     expect(SetRegionAck.regionId).toEqual(1);
@@ -121,7 +121,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
 
     test(`Assert region spectral profile.`, 
     async done => {
-        await Utility.setEvent(Connection, "SET_SPECTRAL_REQUIREMENTS", CARTA.SetSpectralRequirements, 
+        await Utility.setEvent(Connection, CARTA.SetSpectralRequirements, 
             {
                 fileId: 0, 
                 regionId: 1, 
@@ -132,7 +132,7 @@ describe("REGION_SPECTRAL_PROFILE_DEV: Temporary test case of region spectral pr
             }
         );
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "SPECTRAL_PROFILE_DATA", CARTA.SpectralProfileData, 
+            Utility.getEvent(Connection, CARTA.SpectralProfileData, 
                 (SpectralProfileData: CARTA.SpectralProfileData) => {
                     expect(SpectralProfileData.fileId).toEqual(0);
                     expect(SpectralProfileData.regionId).toEqual(1);

--- a/src/test/REGION_STATISTICS_DEV.test.ts
+++ b/src/test/REGION_STATISTICS_DEV.test.ts
@@ -21,27 +21,27 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
 
         async function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
-            await Utility.setEvent(this, "REGISTER_VIEWER", CARTA.RegisterViewer, 
+            await Utility.setEvent(this, CARTA.RegisterViewer, 
                 {
-                    sessionId: "", 
+                    sessionId: 0, 
                     apiKey: "1234"
                 }
             );
             await new Promise( resolve => { 
-                Utility.getEvent(this, "REGISTER_VIEWER_ACK", CARTA.RegisterViewerAck, 
+                Utility.getEvent(this, CARTA.RegisterViewerAck, 
                     RegisterViewerAck => {
                         expect(RegisterViewerAck.success).toBe(true);
                         resolve();           
                     }
                 );
             });
-            await Utility.setEvent(this, "FILE_LIST_REQUEST", CARTA.FileListRequest, 
+            await Utility.setEvent(this, CARTA.FileListRequest, 
                 {
                     directory: expectBasePath
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "FILE_LIST_RESPONSE", CARTA.FileListResponse, 
+                Utility.getEvent(this, CARTA.FileListResponse, 
                         FileListResponseBase => {
                         expect(FileListResponseBase.success).toBe(true);
                         baseDirectory = FileListResponseBase.directory;
@@ -49,7 +49,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
                     }
                 );                
             });
-            await Utility.setEvent(this, "OPEN_FILE", CARTA.OpenFile, 
+            await Utility.setEvent(this, CARTA.OpenFile, 
                 {
                     directory: baseDirectory + "/" + testSubdirectoryName, 
                     file: testFileName, 
@@ -59,14 +59,14 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "OPEN_FILE_ACK", CARTA.OpenFileAck, 
+                Utility.getEvent(this, CARTA.OpenFileAck, 
                     OpenFileAck => {
                         expect(OpenFileAck.success).toBe(true);
                         resolve();
                     }
                 );                
             });
-            await Utility.setEvent(this, "SET_IMAGE_VIEW", CARTA.SetImageView, 
+            await Utility.setEvent(this, CARTA.SetImageView, 
                 {
                     fileId: 0, 
                     imageBounds: {
@@ -80,7 +80,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
                 }
             );
             await new Promise( resolve => {
-                Utility.getEvent(this, "RASTER_IMAGE_DATA", CARTA.RasterImageData, 
+                Utility.getEvent(this, CARTA.RasterImageData, 
                     RasterImageData => {
                         expect(RasterImageData.fileId).toEqual(0);
                         resolve();
@@ -95,7 +95,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
 
     test(`Test to set region.`, 
     async done => {
-        await Utility.setEvent(Connection, "SET_REGION", CARTA.SetRegion, 
+        await Utility.setEvent(Connection, CARTA.SetRegion, 
             {
                 fileId: 0, 
                 regionId: -1, 
@@ -109,7 +109,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
             }
         );        
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "SET_REGION_ACK", CARTA.SetRegionAck, 
+            Utility.getEvent(Connection, CARTA.SetRegionAck, 
                 SetRegionAck => {
                     expect(SetRegionAck.success).toBe(true);
                     expect(SetRegionAck.regionId).toEqual(1);
@@ -122,7 +122,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
 
     test(`Assert region stastics.`, 
     async done => {
-        await Utility.setEvent(Connection, "SET_STATS_REQUIREMENTS", CARTA.SetStatsRequirements, 
+        await Utility.setEvent(Connection, CARTA.SetStatsRequirements, 
             {
                 fileId: 0, regionId: 1, 
                 stats: [
@@ -133,7 +133,7 @@ describe("REGION_STATISTICS_DEV: Temporary test case of region statistics to ass
             }
         );               
         await new Promise( resolve => {
-            Utility.getEvent(Connection, "REGION_STATS_DATA", CARTA.RegionStatsData, 
+            Utility.getEvent(Connection, CARTA.RegionStatsData, 
                 RegionStatsData => {
                     expect(RegionStatsData.fileId).toEqual(0);
                     expect(RegionStatsData.regionId).toEqual(1);


### PR DESCRIPTION
Fix the function about ICD message format to match the protobuf 1.2 `83cf0ba` .

Tested on backend branch `1db111c`.