### PR TITLE
Fix issue #22

### DIFF
--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -165,7 +165,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                                     expect(RegionHistogramData.histograms[0].binWidth).toEqual(0.7235205769538879);
                                     expect(RegionHistogramData.histograms[0].bins.length).toEqual(2775);
                                     expect(RegionHistogramData.histograms[0].channel).toEqual(-2);
-                                    expect(RegionHistogramData.histograms[0].firstBinCenter).toEqual(-1773.299860805273);
+                                    expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(-1773.299860805273, 3);
                                     expect(RegionHistogramData.histograms[0].numBins).toEqual(2775); 
                                     expect(RegionHistogramData.regionId).toEqual(-2);
                                     resolve();
@@ -189,7 +189,7 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                                         expect(RegionHistogramData.histograms[0].bins.length).toEqual(2775);
                                         expect(RegionHistogramData.histograms[0].bins[2500]).toEqual(9359604);
                                         expect(RegionHistogramData.histograms[0].channel).toEqual(-2);
-                                        expect(RegionHistogramData.histograms[0].firstBinCenter).toEqual(-1773.299860805273);
+                                        expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(-1773.299860805273, 3);
                                         expect(RegionHistogramData.histograms[0].numBins).toEqual(2775); 
                                         expect(RegionHistogramData.regionId).toEqual(-2);
                                     }

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -15,7 +15,7 @@
         "readLargeImage": 18000,
         "playImages": 30000,
         "cubeHistogram": 60000,
-        "cancel": 10000,
+        "cancel": 5000,
         "concurrent": 4000,
         "messageEvent": 500,
         "mouseEvent": 1000


### PR DESCRIPTION
Fix issue #22 of per cube histogram cancellation and assert value by less digits.
Modify the config.timeout.cancel to be 5000.
Let messageReturnTimeout = config.timeout.readFile replace the original config.timeout.readLargeImage.