### PR TITLE
Refactor via getEventAsync

### DIFF
--- a/src/test/ACCESS_CARTA_APIKEY.test.ts
+++ b/src/test/ACCESS_CARTA_APIKEY.test.ts
@@ -32,9 +32,10 @@ describe("ACCESS_CARTA_APIKEY tests: Testing connections to the backend with an 
             async function OnOpen(this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-                await Utility.getEventAsync(this, CARTA.RegisterViewerAck, 
-                    (RegisterViewerAck: CARTA.RegisterViewerAck) => {
+                await Utility.getEventAsync(this, CARTA.RegisterViewerAck,  
+                    (RegisterViewerAck: CARTA.RegisterViewerAck, resolve) => {
                         RegisterViewerAckTemp = RegisterViewerAck;
+                        resolve();
                     }
                 );
                 done();
@@ -65,8 +66,9 @@ describe("ACCESS_CARTA_APIKEY tests: Testing connections to the backend with an 
         test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms`, async () => {
             await Utility.setEventAsync(Connection, CARTA.FileListRequest, assertItem.filelist);
             await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
-                (FileListResponse: CARTA.FileListResponse) => {
+                (FileListResponse: CARTA.FileListResponse, resolve) => {
                     FileListResponseTemp = FileListResponse;
+                    resolve();
                 }
             );
         }, connectTimeout);

--- a/src/test/ACCESS_CARTA_DEFAULT.test.ts
+++ b/src/test/ACCESS_CARTA_DEFAULT.test.ts
@@ -27,8 +27,9 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
                 await Utility.getEventAsync(this, CARTA.RegisterViewerAck, 
-                    (RegisterViewerAck: CARTA.RegisterViewerAck) => {
+                    (RegisterViewerAck: CARTA.RegisterViewerAck, resolve) => {
                         RegisterViewerAckTemp = RegisterViewerAck;
+                        resolve();
                     }
                 );
                 await this.close();

--- a/src/test/ACCESS_CARTA_UNKNOWN_APIKEY.test.ts
+++ b/src/test/ACCESS_CARTA_UNKNOWN_APIKEY.test.ts
@@ -29,8 +29,9 @@ describe("ACCESS_CARTA_UNKNOWN_APIKEY tests: Testing connections to the backend 
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
                 await Utility.getEventAsync(this, CARTA.RegisterViewerAck, 
-                    (RegisterViewerAck: CARTA.RegisterViewerAck) => {
+                    (RegisterViewerAck: CARTA.RegisterViewerAck, resolve) => {
                         RegisterViewerAckTemp = RegisterViewerAck;
+                        resolve();
                     }
                 );
                 done();

--- a/src/test/ACCESS_CARTA_UNKNOWN_SESSION.test.ts
+++ b/src/test/ACCESS_CARTA_UNKNOWN_SESSION.test.ts
@@ -27,8 +27,9 @@ describe("ACCESS_CARTA_UNKNOWN_SESSION tests: Testing connections to the backend
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
                 await Utility.getEventAsync(this, CARTA.RegisterViewerAck, 
-                    (RegisterViewerAck: CARTA.RegisterViewerAck) => {
+                    (RegisterViewerAck: CARTA.RegisterViewerAck, resolve) => {
                         RegisterViewerAckTemp = RegisterViewerAck;
+                        resolve();
                     }
                 );
                 await this.close();

--- a/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
+++ b/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
@@ -2,158 +2,177 @@ import {CARTA} from "carta-protobuf";
 import * as Utility from "./testUtilityFunction";
 import config from "./config.json";
 let testServerUrl = config.serverURL;
-let testSubdirectoryName = config.path.QA;
+let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
 let readFileTimeout = config.timeout.readFile;
-
-interface ImageAssertItem {
-    fileId: number;
-    hdu: string;
-    fileInfo: any;
-    fileInfoExtended: any;
-    computedEntries: CARTA.IHeaderEntry[];
-    headerEntries: CARTA.IHeaderEntry[];
-    imageDataInfo: {
-        imageBounds: {xMin: number, xMax: number, yMin: number, yMax: number};
-        compressionType: CARTA.CompressionType;
-        mip: number;
-        channel: number;
-        stokes: number;
-    }
-    channelHistogramData: {
-        numBins: number;
-        lengthOfBins: number;
-        binWidth: number;
-        firstBinCenter: number;
-        binValue: {binIndex: number, value: number}[];
-        sumOfBinCount: number;
-    }
-    nanEncodings: {
-        length: number;
-    }
-    imageData: {
-        length: number;
-        assertPoints: {point: {x: number, y: number, xMax: number}, value: number}[];
-    }
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    fileOpenAck: CARTA.IOpenFileAck;
+    setImageView: CARTA.ISetImageView;
+    rasterImageData: CARTA.IRasterImageData;
+    assert: {
+        channelHistogramData: {
+            numBins: number;
+            lengthOfBins: number;
+            binWidth: number;
+            firstBinCenter: number;
+            binValue: {binIndex: number, value: number}[];
+            sumOfBinCount: number;
+        }
+        nanEncodings: {
+            length: number;
+        }
+        imageData: {
+            length: number;
+            assertPoints: {point: {x: number, y: number, xMax: number}, value: number}[];
+        }
+    };
 }
-let imageAssertItem: ImageAssertItem = {
-    fileId: 0,
-    hdu: "0",
-    fileInfo: {
-        HDUList: ["0"], 
-        name: "G14.114-0.574.continuum.image.pbcor.fits", 
-        size: 4337280,
-    },    
-    fileInfoExtended: {
-        stokesVals: [""],
-        dimensions: 4,
-        width: 1024,
-        height: 1024,
-        depth: 1,
-        stokes: 1 
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
     },
-    computedEntries: [
-        {
-            name: 'Name',
-            value: 'G14.114-0.574.continuum.image.pbcor.fits' },
-        { name: 'Shape', value: '[1024, 1024, 1, 1]' },
-        {
-            name: 'Number of channels',
-            value: '1',
-            entryType: 2,
-            numericValue: 1 },
-        {
-            name: 'Number of Stokes',
-            value: '1',
-            entryType: 2,
-            numericValue: 1 },
-        { name: 'Coordinate type', value: 'RA---SIN, DEC--SIN' },
-        { name: 'Image reference pixels', value: '[513, 513] ' },
-        {
-            name: 'Image reference coordinates',
-            value: '[274.5623 deg, -16.9498 deg]' },
-        {
-            name: 'Image ref coords (coord type)',
-            value: '[18:18:14.9466, -016.56.59.3264]' },
-        { name: 'Celestial frame', value: 'ICRS' },
-        { name: 'Spectral frame', value: 'TOPOCENT' },
-        { name: 'Pixel unit', value: 'Jy/beam' },
-        { name: 'Pixel increment', value: '-0.50", 0.50"' },
-        { name: 'Restoring beam', value: '3.77" X 1.88", 86.4304 deg' }
-    ],
-    headerEntries: [
-        {
-            name: 'BMAJ',
-            value: '0.00104662',
-            entryType: 1,
-            numericValue: 0.00104662431611 },
-        {
-            name: 'BMIN',
-            value: '0.000521827',
-            entryType: 1,
-            numericValue: 0.0005218272076713 },
-        {
-            name: 'BPA',
-            value: '86.4304',
-            entryType: 1,
-            numericValue: 86.43037414551 },
-        { name: 'LONPOLE', value: '180', entryType: 1, numericValue: 180 },
-        {
-            name: 'LATPOLE',
-            value: '-16.9498',
-            entryType: 1,
-            numericValue: -16.94981289706 },
-        { name: 'CTYPE3', value: 'FREQ' },
-        {
-            name: 'CRVAL3',
-            value: '1.04008e+11',
-            entryType: 1,
-            numericValue: 104008101097.8 },
-        {
-            name: 'CDELT3',
-            value: '4.00019e+09',
-            entryType: 1,
-            numericValue: 4000189550.454 },
-        { name: 'CRPIX3', value: '1', entryType: 1, numericValue: 1 },
-        { name: 'CUNIT3', value: 'Hz' },
-        { name: 'CTYPE4', value: 'STOKES' },
-        { name: 'CRVAL4', value: '1', entryType: 1, numericValue: 1 },
-        { name: 'CDELT4', value: '1', entryType: 1, numericValue: 1 },
-        { name: 'CRPIX4', value: '1', entryType: 1, numericValue: 1 },
-        { name: 'CUNIT4' },
-        {
-            name: 'RESTFRQ',
-            value: '1.03e+11',
-            entryType: 1,
-            numericValue: 103000000000 },
-        { name: 'VELREF', value: '259', entryType: 2, numericValue: 259 },
-    ],
-    imageDataInfo: {
+    filelist: {directory: testSubdirectory},    
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "G14.114-0.574.continuum.image.pbcor.fits",
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    fileOpenAck: {
+            success: true,
+            fileId: 0,
+            fileInfo: {
+                name: "G14.114-0.574.continuum.image.pbcor.fits",
+                type: CARTA.FileType.FITS,
+                size: 4337280,
+                HDUList: ["0"],
+            },
+            fileInfoExtended: {
+                dimensions: 4,
+                width: 1024,
+                height: 1024,
+                depth: 1,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [
+                    {
+                        name: 'BMAJ',
+                        value: '0.00104662',
+                        entryType: 1,
+                        numericValue: 0.00104662431611 },
+                    {
+                        name: 'BMIN',
+                        value: '0.000521827',
+                        entryType: 1,
+                        numericValue: 0.0005218272076713 },
+                    {
+                        name: 'BPA',
+                        value: '86.4304',
+                        entryType: 1,
+                        numericValue: 86.43037414551 },
+                    { name: 'LONPOLE', value: '180', entryType: 1, numericValue: 180 },
+                    {
+                        name: 'LATPOLE',
+                        value: '-16.9498',
+                        entryType: 1,
+                        numericValue: -16.94981289706 },
+                    { name: 'CTYPE3', value: 'FREQ' },
+                    {
+                        name: 'CRVAL3',
+                        value: '1.04008e+11',
+                        entryType: 1,
+                        numericValue: 104008101097.8 },
+                    {
+                        name: 'CDELT3',
+                        value: '4.00019e+09',
+                        entryType: 1,
+                        numericValue: 4000189550.454 },
+                    { name: 'CRPIX3', value: '1', entryType: 1, numericValue: 1 },
+                    { name: 'CUNIT3', value: 'Hz' },
+                    { name: 'CTYPE4', value: 'STOKES' },
+                    { name: 'CRVAL4', value: '1', entryType: 1, numericValue: 1 },
+                    { name: 'CDELT4', value: '1', entryType: 1, numericValue: 1 },
+                    { name: 'CRPIX4', value: '1', entryType: 1, numericValue: 1 },
+                    { name: 'CUNIT4' },
+                    {
+                        name: 'RESTFRQ',
+                        value: '1.03e+11',
+                        entryType: 1,
+                        numericValue: 103000000000 },
+                    { name: 'VELREF', value: '259', entryType: 2, numericValue: 259 },
+                ],
+                computedEntries: [
+                    {
+                        name: 'Name',
+                        value: 'G14.114-0.574.continuum.image.pbcor.fits' },
+                    { name: 'Shape', value: '[1024, 1024, 1, 1]' },
+                    {
+                        name: 'Number of channels',
+                        value: '1',
+                        entryType: 2,
+                        numericValue: 1 },
+                    {
+                        name: 'Number of Stokes',
+                        value: '1',
+                        entryType: 2,
+                        numericValue: 1 },
+                    { name: 'Coordinate type', value: 'RA---SIN, DEC--SIN' },
+                    { name: 'Image reference pixels', value: '[513, 513] ' },
+                    {
+                        name: 'Image reference coordinates',
+                        value: '[274.5623 deg, -16.9498 deg]' },
+                    {
+                        name: 'Image ref coords (coord type)',
+                        value: '[18:18:14.9466, -016.56.59.3264]' },
+                    { name: 'Celestial frame', value: 'ICRS' },
+                    { name: 'Spectral frame', value: 'TOPOCENT' },
+                    { name: 'Pixel unit', value: 'Jy/beam' },
+                    { name: 'Pixel increment', value: '-0.50", 0.50"' },
+                    { name: 'Restoring beam', value: '3.77" X 1.88", 86.4304 deg' }
+                ],
+            },
+    },
+    setImageView: {
+        fileId: 0,
         imageBounds: {xMin: 0, xMax: 1024, yMin: 0, yMax: 1024},
-        compressionType: CARTA.CompressionType.NONE,
         mip: 3,
+        compressionType: CARTA.CompressionType.NONE,
+    },
+    rasterImageData: {
+        fileId: 0,
+        imageBounds: {xMin: 0, xMax: 1024, yMin: 0, yMax: 1024},
         channel: 0,
         stokes: 0,
+        mip: 3,
+        compressionType: CARTA.CompressionType.NONE,
+        compressionQuality: 0,
     },
-    channelHistogramData: {
-        numBins: 1024,
-        lengthOfBins: 1024,
-        binWidth: 0.000010574989573797211,
-        firstBinCenter:  -0.0012399675051710801,
-        binValue: [{binIndex: 117, value: 11452}],
-        sumOfBinCount: 302412,
-    },
-    nanEncodings: {
-        length: 0,
-    },
-    imageData: {
-        length: 465124,
-        assertPoints: [
-            {point: {x: 190, y: 156, xMax: 341}, value: 0.005836978}, 
-            {point: {x: 155, y: 127, xMax: 341}, value: 0.0002207166},
-        ],
-    },
+    assert: {
+        channelHistogramData: {
+            numBins: 1024,
+            lengthOfBins: 1024,
+            binWidth: 0.000010574989573797211,
+            firstBinCenter:  -0.0012399675051710801,
+            binValue: [{binIndex: 117, value: 11452}],
+            sumOfBinCount: 302412,
+        },
+        nanEncodings: {
+            length: 0,
+        },
+        imageData: {
+            length: 465124,
+            assertPoints: [
+                {point: {x: 190, y: 156, xMax: 341}, value: 0.005836978}, 
+                {point: {x: 155, y: 127, xMax: 341}, value: 0.0002207166},
+            ],
+        },
+    }
 }
 
 describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMAGE_DATA without compression", () => {   
@@ -165,157 +184,122 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
         Connection.onopen = OnOpen;
 
         async function OnOpen (this: WebSocket, ev: Event) {
-            await Utility.setEvent(this, CARTA.RegisterViewer, 
-                {
-                    sessionId: 0, 
-                    apiKey: ""
-                }
-            );
-            await new Promise( resolve => { 
-                Utility.getEvent(this, CARTA.RegisterViewerAck, 
-                    RegisterViewerAck => {
-                        expect(RegisterViewerAck.success).toBe(true);
-                        resolve();           
-                    }
-                );
-            });
-            await done();
+            await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
+            done();   
         }
     }, connectTimeout);
     
-    describe(`Go to "${testSubdirectoryName}" folder`, () => {
+    describe(`Go to "${testSubdirectory}" folder`, () => {
 
         beforeAll( async () => {            
-            await Utility.setEvent(Connection, CARTA.CloseFile, 
-                {
-                    fileId: -1,
-                }
-            );
+            await Utility.setEvent(Connection, CARTA.CloseFile, {fileId: -1});
         });
         
-        describe(`Open image "${imageAssertItem.fileInfo.name}"`, () => {
+        describe(`Open image "${assertItem.fileOpen.file}"`, () => {
             let OpenFileAckTemp: CARTA.OpenFileAck;
             test(`OPEN_FILE_ACK should arrive within ${openFileTimeout} ms.`, async () => {
-                await Utility.setEvent(Connection, CARTA.OpenFile, 
-                    {
-                        directory: testSubdirectoryName, 
-                        file: imageAssertItem.fileInfo.name,
-                        fileId: imageAssertItem.fileId,
-                        hdu: imageAssertItem.hdu,
-                        renderMode: CARTA.RenderMode.RASTER,
+                await Utility.setEventAsync(Connection, CARTA.OpenFile, assertItem.fileOpen);
+                await Utility.getEventAsync(Connection, CARTA.OpenFileAck,  
+                    (OpenFileAck: CARTA.OpenFileAck, resolve) => {
+                        OpenFileAckTemp = OpenFileAck;
+                        resolve();
                     }
-                ); 
-                await new Promise( resolve => {           
-                    Utility.getEvent(Connection, CARTA.OpenFileAck, 
-                        (OpenFileAck: CARTA.OpenFileAck) => {
-                            OpenFileAckTemp = OpenFileAck;
-                            resolve();
-                        }
-                    );
-                });
+                );
             }, openFileTimeout);            
 
-            test("OPEN_FILE_ACK.success = true", () => {
-                expect(OpenFileAckTemp.success).toBe(true);
+            test(`OPEN_FILE_ACK.success = ${assertItem.fileOpenAck.success}`, () => {
+                expect(OpenFileAckTemp.success).toBe(assertItem.fileOpenAck.success);
             });
 
-            test(`OPEN_FILE_ACK.file_info.file_id = ${imageAssertItem.fileId}`, () => {
-                expect(OpenFileAckTemp.fileId).toEqual(imageAssertItem.fileId);
+            test(`OPEN_FILE_ACK.file_info.file_id = ${assertItem.fileOpenAck.fileId}`, () => {
+                expect(OpenFileAckTemp.fileId).toEqual(assertItem.fileOpenAck.fileId);
             });
 
-            test("assert OPEN_FILE_ACK.file_info", () => {
-                expect(OpenFileAckTemp.fileInfo.HDUList).toEqual(imageAssertItem.fileInfo.HDUList);
-                expect(OpenFileAckTemp.fileInfo.name).toEqual(imageAssertItem.fileInfo.name);
-                expect(OpenFileAckTemp.fileInfo.size.toString()).toEqual(imageAssertItem.fileInfo.size.toString());
+            test("Assert OPEN_FILE_ACK.file_info", () => {
+                expect(OpenFileAckTemp.fileInfo.HDUList).toEqual(assertItem.fileOpenAck.fileInfo.HDUList);
+                expect(OpenFileAckTemp.fileInfo.name).toEqual(assertItem.fileOpenAck.fileInfo.name);
+                expect(OpenFileAckTemp.fileInfo.size.toString()).toEqual(assertItem.fileOpenAck.fileInfo.size.toString());
             });
 
             test("assert OPEN_FILE_ACK.file_info_extended", () => {                
-                expect(OpenFileAckTemp.fileInfoExtended.depth).toEqual(imageAssertItem.fileInfoExtended.depth);               
-                expect(OpenFileAckTemp.fileInfoExtended.height).toEqual(imageAssertItem.fileInfoExtended.height);               
-                expect(OpenFileAckTemp.fileInfoExtended.width).toEqual(imageAssertItem.fileInfoExtended.width);               
-                expect(OpenFileAckTemp.fileInfoExtended.stokes).toEqual(imageAssertItem.fileInfoExtended.stokes);               
-                expect(OpenFileAckTemp.fileInfoExtended.stokesVals).toEqual(imageAssertItem.fileInfoExtended.stokesVals);               
-                expect(OpenFileAckTemp.fileInfoExtended.dimensions).toEqual(imageAssertItem.fileInfoExtended.dimensions);
+                expect(OpenFileAckTemp.fileInfoExtended.depth).toEqual(assertItem.fileOpenAck.fileInfoExtended.depth);               
+                expect(OpenFileAckTemp.fileInfoExtended.height).toEqual(assertItem.fileOpenAck.fileInfoExtended.height);               
+                expect(OpenFileAckTemp.fileInfoExtended.width).toEqual(assertItem.fileOpenAck.fileInfoExtended.width);               
+                expect(OpenFileAckTemp.fileInfoExtended.stokes).toEqual(assertItem.fileOpenAck.fileInfoExtended.stokes);               
+                expect(OpenFileAckTemp.fileInfoExtended.stokesVals).toEqual(assertItem.fileOpenAck.fileInfoExtended.stokesVals);               
+                expect(OpenFileAckTemp.fileInfoExtended.dimensions).toEqual(assertItem.fileOpenAck.fileInfoExtended.dimensions);
             });
 
             test("assert OPEN_FILE_ACK.file_info_extended.computed_entries", () => {
-                imageAssertItem.computedEntries.map( (entry: CARTA.IHeaderEntry) => {
+                assertItem.fileOpenAck.fileInfoExtended.computedEntries.map( (entry: CARTA.IHeaderEntry) => {
                     expect(OpenFileAckTemp.fileInfoExtended.computedEntries).toContainEqual(entry);
                 });
             });
 
             test("assert OPEN_FILE_ACK.file_info_extended.header_entries", () => { 
-                imageAssertItem.headerEntries.map( (entry: CARTA.IHeaderEntry) => {
+                assertItem.fileOpenAck.fileInfoExtended.headerEntries.map( (entry: CARTA.IHeaderEntry) => {
                     expect(OpenFileAckTemp.fileInfoExtended.headerEntries).toContainEqual(entry);
                 });
             });
 
         });
 
-        describe(`Set image view for "${imageAssertItem.fileInfo.name}"`, () => {
+        describe(`Set image view for "${assertItem.fileOpen.file}"`, () => {
             let RasterImageDataTemp: CARTA.RasterImageData;
             test(`RASTER_IMAGE_DATA should arrive within ${openFileTimeout} ms.`, async () => {
-                await Utility.setEvent(Connection, CARTA.SetImageView, 
-                    {
-                        fileId: imageAssertItem.fileId, 
-                        imageBounds: imageAssertItem.imageDataInfo.imageBounds, 
-                        mip: imageAssertItem.imageDataInfo.mip, 
-                        compressionType: imageAssertItem.imageDataInfo.compressionType,
+                await Utility.setEventAsync(Connection, CARTA.SetImageView, assertItem.setImageView);
+                await Utility.getEventAsync(Connection, CARTA.RasterImageData,  
+                    (RasterImageData: CARTA.RasterImageData, resolve) => {
+                        RasterImageDataTemp = RasterImageData;
+                        resolve();
                     }
                 );
-                await new Promise( resolve => {
-                    Utility.getEvent(Connection, CARTA.RasterImageData, 
-                        (RasterImageData: CARTA.RasterImageData) => {
-                            RasterImageDataTemp = RasterImageData;
-                            resolve();
-                        }
-                    );                            
-                });
             }, readFileTimeout);
 
-            test(`RASTER_IMAGE_DATA.file_id = ${imageAssertItem.fileId}`, () => {
-                expect(RasterImageDataTemp.fileId).toEqual(imageAssertItem.fileId);
+            test(`RASTER_IMAGE_DATA.file_id = ${assertItem.rasterImageData.fileId}`, () => {
+                expect(RasterImageDataTemp.fileId).toEqual(assertItem.rasterImageData.fileId);
             });
 
-            test(`RASTER_IMAGE_DATA.image_bounds = {xMax: ${imageAssertItem.imageDataInfo.imageBounds.xMax}, yMax: ${imageAssertItem.imageDataInfo.imageBounds.yMax}}`, () => {
-                expect(RasterImageDataTemp.imageBounds).toEqual({xMax: imageAssertItem.imageDataInfo.imageBounds.xMax, yMax: imageAssertItem.imageDataInfo.imageBounds.yMax});
+            test(`RASTER_IMAGE_DATA.image_bounds = {xMax: ${assertItem.rasterImageData.imageBounds}, yMax: ${assertItem.rasterImageData.imageBounds.yMax}}`, () => {
+                expect(RasterImageDataTemp.imageBounds).toEqual({xMax: assertItem.rasterImageData.imageBounds.xMax, yMax: assertItem.rasterImageData.imageBounds.yMax});
             });
 
-            test(`RASTER_IMAGE_DATA.compression_type = ${CARTA.CompressionType[imageAssertItem.imageDataInfo.compressionType]}`, () => {
-                expect(RasterImageDataTemp.compressionType).toEqual(imageAssertItem.imageDataInfo.compressionType);
+            test(`RASTER_IMAGE_DATA.compression_type = ${CARTA.CompressionType[assertItem.rasterImageData.compressionType]}`, () => {
+                expect(RasterImageDataTemp.compressionType).toEqual(assertItem.rasterImageData.compressionType);
             });
 
-            test(`RASTER_IMAGE_DATA.channel = ${imageAssertItem.imageDataInfo.channel}`, () => {
-                expect(RasterImageDataTemp.channel).toEqual(imageAssertItem.imageDataInfo.channel);
+            test(`RASTER_IMAGE_DATA.channel = ${assertItem.rasterImageData.channel}`, () => {
+                expect(RasterImageDataTemp.channel).toEqual(assertItem.rasterImageData.channel);
             });
 
-            test(`RASTER_IMAGE_DATA.stokes = ${imageAssertItem.imageDataInfo.stokes}`, () => {
-                expect(RasterImageDataTemp.stokes).toEqual(imageAssertItem.imageDataInfo.stokes);
+            test(`RASTER_IMAGE_DATA.stokes = ${assertItem.rasterImageData.stokes}`, () => {
+                expect(RasterImageDataTemp.stokes).toEqual(assertItem.rasterImageData.stokes);
             });
 
             test("Assert RASTER_IMAGE_DATA.channel_histogram_data", () => {
-                expect(RasterImageDataTemp.channelHistogramData.histograms[0].numBins).toEqual(imageAssertItem.channelHistogramData.numBins);
-                expect(RasterImageDataTemp.channelHistogramData.histograms[0].bins.length).toEqual(imageAssertItem.channelHistogramData.lengthOfBins);
-                expect(RasterImageDataTemp.channelHistogramData.histograms[0].binWidth).toBeCloseTo(imageAssertItem.channelHistogramData.binWidth, 8);
-                expect(RasterImageDataTemp.channelHistogramData.histograms[0].firstBinCenter).toBeCloseTo(imageAssertItem.channelHistogramData.firstBinCenter, 8);
-                imageAssertItem.channelHistogramData.binValue.map( item => {
+                expect(RasterImageDataTemp.channelHistogramData.histograms[0].numBins).toEqual(assertItem.assert.channelHistogramData.numBins);
+                expect(RasterImageDataTemp.channelHistogramData.histograms[0].bins.length).toEqual(assertItem.assert.channelHistogramData.lengthOfBins);
+                expect(RasterImageDataTemp.channelHistogramData.histograms[0].binWidth).toBeCloseTo(assertItem.assert.channelHistogramData.binWidth, 8);
+                expect(RasterImageDataTemp.channelHistogramData.histograms[0].firstBinCenter).toBeCloseTo(assertItem.assert.channelHistogramData.firstBinCenter, 8);
+                assertItem.assert.channelHistogramData.binValue.map( item => {
                     expect(RasterImageDataTemp.channelHistogramData.histograms[0].bins[item.binIndex]).toEqual(item.value);
                 });
-                expect(RasterImageDataTemp.channelHistogramData.histograms[0].bins.reduce((sum, next) => sum += next)).toEqual(imageAssertItem.channelHistogramData.sumOfBinCount);
+                expect(RasterImageDataTemp.channelHistogramData.histograms[0].bins.reduce((sum, next) => sum += next)).toEqual(assertItem.assert.channelHistogramData.sumOfBinCount);
             });
 
             test("Assert RASTER_IMAGE_DATA.nan_encodings", () => {
-                expect(RasterImageDataTemp.nanEncodings.length).toEqual(imageAssertItem.nanEncodings.length);
+                expect(RasterImageDataTemp.nanEncodings.length).toEqual(assertItem.assert.nanEncodings.length);
             });
 
             test("Assert RASTER_IMAGE_DATA.image_data", () => {
                 let _sum: number = 0;
                 RasterImageDataTemp.imageData.map(item => _sum += item.length);
-                expect(_sum).toEqual(imageAssertItem.imageData.length);
-                if (imageAssertItem.fileInfo.compressionType === CARTA.CompressionType.NONE) {
-                    imageAssertItem.imageData.assertPoints.map( assertPoint => {
+                expect(_sum).toEqual(assertItem.assert.imageData.length);
+                if (assertItem.rasterImageData.compressionType === CARTA.CompressionType.NONE) {
+                    assertItem.assert.imageData.assertPoints.map( assertPoint => {
                         let _movingIndex = 4 * ( assertPoint.point.y * assertPoint.point.xMax + assertPoint.point.x );
-                        expect(Buffer.from(imageAssertItem.imageData[0].slice(_movingIndex, _movingIndex + 4)).readFloatLE(0)).toBeCloseTo(assertPoint.value, 8);
+                        expect(Buffer.from(RasterImageDataTemp.imageData[0].slice(_movingIndex, _movingIndex + 4)).readFloatLE(0)).toBeCloseTo(assertPoint.value, 8);
                     });
                 }
             });

--- a/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
+++ b/src/test/CHECK_RASTER_IMAGE_DATA_noCompression.test.ts
@@ -193,7 +193,7 @@ describe("CHECK_RASTER_IMAGE_DATA_noCompression test: Testing message RASTER_IMA
     describe(`Go to "${testSubdirectory}" folder`, () => {
 
         beforeAll( async () => {            
-            await Utility.setEvent(Connection, CARTA.CloseFile, {fileId: -1});
+            await Utility.setEventAsync(Connection, CARTA.CloseFile, {fileId: -1});
         });
         
         describe(`Open image "${assertItem.fileOpen.file}"`, () => {

--- a/src/test/FILEINFO.test.ts
+++ b/src/test/FILEINFO.test.ts
@@ -2,385 +2,473 @@ import {CARTA} from "carta-protobuf";
 import * as Utility from "./testUtilityFunction";
 import config from "./config.json";
 let testServerUrl = config.serverURL;
-let testSubdirectoryName = config.path.QA;
+let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let listFileTimeout = config.timeout.listFile;
 let openFileTimeout = config.timeout.openFile;
-interface ImageAssertItem {
-    fileName: string;
-    hdu: string;
-    HDUList: string[];
-    fileSize: number;
-    fileType: CARTA.FileType;
-    shape: number[];
-    NAXIS: number;
-    computedEntries: CARTA.IHeaderEntry[];
-    headerEntries: CARTA.IHeaderEntry[];
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileInfoGroup: CARTA.IFileInfoRequest[];
+    fileInfoResGroup: CARTA.IFileInfoResponse[];
 }
-let imageAssertItems: ImageAssertItem[] = [
-    {
-        fileName: "M17_SWex.fits", 
-        hdu: "0", HDUList: ["0"], 
-        fileSize: 51393600, 
-        fileType: CARTA.FileType.FITS, 
-        shape: [640, 800, 25, 1], NAXIS: 4, 
-        computedEntries: [ 
-            { name: "Name", value: "M17_SWex.fits" },
-            { name: "Shape", value: "[640, 800, 25, 1]" },
-            {
-                name: "Number of channels",
-                value: "25",
-                entryType: 2,
-                numericValue: 25 },
-            {
-                name: "Number of Stokes",
-                value: "1",
-                entryType: 2,
-                numericValue: 1 },
-            { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
-            { name: "Image reference pixels", value: "[321, 401] " },
-            {
-                name: "Image reference coordinates",
-                value: "[275.0875 deg, -16.2028 deg]" },
-            {
-                name: "Image ref coords (coord type)",
-                value: "[18:20:21.0000, -016.12.10.0000]" },
-            { name: "Celestial frame", value: "ICRS" },
-            { name: "Spectral frame", value: "LSRK" },
-            { name: "Pixel unit", value: "Jy/beam" },
-            { name: "Pixel increment", value: "-0.40\", 0.40\"" },
-            { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } 
-        ],
-        headerEntries: [ 
-            { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
-            { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
-            { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
-            { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
-            { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
-            {
-                name: "BMAJ",
-                value: "0.000572514",
-                entryType: 1,
-                numericValue: 0.0005725136068132 },
-            {
-                name: "BMIN",
-                value: "0.000414239",
-                entryType: 1,
-                numericValue: 0.00041423857212070003 },
-            {
-                name: "BPA",
-                value: "-74.6267",
-                entryType: 1,
-                numericValue: -74.62673187256 },
-            { name: "BUNIT", value: "Jy/beam" },
-            { name: "LONPOLE", value: "180", entryType: 1, numericValue: 180 },
-            {
-                name: "LATPOLE",
-                value: "-16.2028",
-                entryType: 1,
-                numericValue: -16.20277777779 },
-            { name: "CTYPE3", value: "FREQ" },
-            {
-                name: "CRVAL3",
-                value: "8.67514e+10",
-                entryType: 1,
-                numericValue: 86751396188.4 },
-            {
-                name: "CDELT3",
-                value: "-244238",
-                entryType: 1,
-                numericValue: -244237.7011414 },
-            { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT3", value: "Hz" },
-            { name: "CTYPE4", value: "STOKES" },
-            { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT4" },
-            {
-                name: "RESTFRQ",
-                value: "8.67543e+10",
-                entryType: 1,
-                numericValue: 86754290000 },
-            { name: "VELREF", value: "257", entryType: 2, numericValue: 257 },
-        ], 
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
     },
-    {
-        fileName: "M17_SWex.image", 
-        hdu: "", HDUList: [""], 
-        fileSize: 53009869, 
-        fileType: CARTA.FileType.CASA, 
-        shape: [640, 800, 25, 1], NAXIS: 4, 
-        computedEntries: [ 
-            { name: "Name", value: "M17_SWex.image" },
-            { name: "Shape", value: "[640, 800, 25, 1]" },
-            {
-                name: "Number of channels",
-                value: "25",
-                entryType: 2,
-                numericValue: 25 },
-            {
-                name: "Number of Stokes",
-                value: "1",
-                entryType: 2,
-                numericValue: 1 },
-            { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
-            { name: "Image reference pixels", value: "[321, 401]" },
-            {
-                name: "Image reference coordinates",
-                value: "[275.088 deg, -16.203 deg]" },
-            {
-                name: "Image ref coords (coord type)",
-                value: "[18:20:21.0000 -016.12.10.0000]" },
-            { name: "Celestial frame", value: "ICRS, 2000" },
-            { name: "Spectral frame", value: "LSRK" },
-            { name: "Pixel unit", value: "Jy/beam" },
-            { name: "Pixel increment", value: "-0.40\", 0.40\"" },
-            { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } ],
-        headerEntries: [
-            { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
-            { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
-            { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
-            { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
-            { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
-            {
-                name: "BMAJ",
-                value: "0.000572514",
-                entryType: 1,
-                numericValue: 0.0005725136068132 },
-            {
-                name: "BMIN",
-                value: "0.000414239",
-                entryType: 1,
-                numericValue: 0.0004142385721207 },
-            {
-                name: "BPA",
-                value: "-74.6267",
-                entryType: 1,
-                numericValue: -74.6267318725586 },
-            { name: "BUNIT", value: "Jy/beam" },
-            { name: "CTYPE3", value: "Frequency" },
-            {
-                name: "CRVAL3",
-                value: "8.67514e+10",
-                entryType: 1,
-                numericValue: 86751396188.4 },
-            {
-                name: "CDELT3",
-                value: "-244238",
-                entryType: 1,
-                numericValue: -244237.7011414 },
-            { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT3", value: "Hz" },
-            { name: "CTYPE4", value: "Stokes" },
-            { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT4" },
-            {
-                name: "RESTFRQ",
-                value: "8.67543e+10 Hz\n",
-                entryType: 1,
-                numericValue: 86754290000 },
-        ], 
-    },
-    {
-        fileName: "M17_SWex.hdf5", 
-        hdu: "0", HDUList: ["0"], 
-        fileSize: 112823720, 
-        fileType: CARTA.FileType.HDF5, 
-        shape: [640, 800, 25, 1], NAXIS: 4, 
-        computedEntries: [ 
-            { name: "Name", value: "M17_SWex.hdf5" },
-            { name: "Shape", value: "[640, 800, 25, 1]" },
-            {
-                name: "Number of channels",
-                value: "25",
-                entryType: 2,
-                numericValue: 25 },
-            {
-                name: "Number of Stokes",
-                value: "1",
-                entryType: 2,
-                numericValue: 1 },
-            { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
-            {
-                name: "Image reference pixels",
-                value: "[3.210000000000E+02, 4.010000000000E+02] " },
-            {
-                name: "Image reference coordinates",
-                value: "[275.0875 deg, -16.2028 deg]" },
-            {
-                name: "Image ref coords (coord type)",
-                value: "[18:20:21.0000, -016.12.10.0000]" },
-            { name: "Celestial frame", value: "ICRS" },
-            { name: "Spectral frame", value: "LSRK" },
-            { name: "Pixel unit", value: "Jy/beam" },
-            { name: "Pixel increment", value: "-0.40\", 0.40\"" },
-            { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } ],
-        headerEntries: [
-            { name: "NAXIS", value: "4" },
-            { name: "NAXIS1", value: "640" },
-            { name: "NAXIS2", value: "800" },
-            { name: "NAXIS3", value: "25" },
-            { name: "NAXIS4", value: "1" },
-            { name: "BMAJ", value: "5.725136068132E-04" },
-            { name: "BMIN", value: "4.142385721207E-04" },
-            { name: "BPA", value: "-7.462673187256E+01" },
-            { name: "BUNIT", value: "Jy/beam" },
-            { name: "LONPOLE", value: "1.800000000000E+02" },
-            { name: "LATPOLE", value: "-1.620277777779E+01" },
-            { name: "CTYPE3", value: "FREQ" },
-            { name: "CRVAL3", value: "8.675139618840E+10" },
-            { name: "CDELT3", value: "-2.442377011414E+05" },
-            { name: "CRPIX3", value: "1.000000000000E+00" },
-            { name: "CUNIT3", value: "Hz" },
-            { name: "CTYPE4", value: "STOKES" },
-            { name: "CRVAL4", value: "1.000000000000E+00" },
-            { name: "CDELT4", value: "1.000000000000E+00" },
-            { name: "CRPIX4", value: "1.000000000000E+00" },
-            { name: "CUNIT4" },
-            { name: "RESTFRQ", value: "8.675429000000E+10" },,
-            { name: "VELREF", value: "257" },
-        ], 
-    },
-    {
-        fileName: "M17_SWex.miriad", 
-        hdu: "", HDUList: [""], 
-        fileSize: 52993642, 
-        fileType: CARTA.FileType.MIRIAD, 
-        shape: [640, 800, 25, 1], NAXIS: 4, 
-        computedEntries: [ 
-            { name: "Name", value: "M17_SWex.miriad" },
-            { name: "Shape", value: "[640, 800, 25, 1]" },
-            {
-                name: "Number of channels",
-                value: "25",
-                entryType: 2,
-                numericValue: 25 },
-            {
-                name: "Number of Stokes",
-                value: "1",
-                entryType: 2,
-                numericValue: 1 },
-            { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
-            { name: "Image reference pixels", value: "[321, 401]" },
-            {
-                name: "Image reference coordinates",
-                value: "[275.088 deg, -16.203 deg]" },
-            {
-                name: "Image ref coords (coord type)",
-                value: "[18:20:21.0000 -016.12.10.0000]" },
-            { name: "Celestial frame", value: "FK5, J2000" },
-            { name: "Spectral frame", value: "BARYCENT" },
-            { name: "Pixel unit", value: "Jy/beam" },
-            { name: "Pixel increment", value: "-0.40\", 0.40\"" },
-            { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } ],
-        headerEntries: [ 
-            { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
-            { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
-            { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
-            { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
-            { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
-            {
-                name: "BMAJ",
-                value: "0.000572514",
-                entryType: 1,
-                numericValue: 0.0005725135932445429 },
-            {
-                name: "BMIN",
-                value: "0.000414239",
-                entryType: 1,
-                numericValue: 0.00041423858135383447 },
-            {
-                name: "BPA",
-                value: "-74.6267",
-                entryType: 1,
-                numericValue: -74.6267318725586 },
-            { name: "BUNIT", value: "Jy/beam" },
-            { name: "CTYPE3", value: "Frequency" },
-            {
-                name: "CRVAL3",
-                value: "8.67514e+10",
-                entryType: 1,
-                numericValue: 86751396188.40004 },
-            {
-                name: "CDELT3",
-                value: "-244238",
-                entryType: 1,
-                numericValue: -244237.7011414 },
-            { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT3", value: "Hz" },
-            { name: "CTYPE4", value: "Stokes" },
-            { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
-            { name: "CUNIT4" },
-            {
-                name: "RESTFRQ",
-                value: "8.67543e+10 Hz\n",
-                entryType: 1,
-                numericValue: 86754290000.00003 },
-        ], 
-    },
-    {
-        fileName: "spire500_ext.fits", 
-        hdu: "0", HDUList: ["1 ExtName: image", "6 ExtName: error", "7 ExtName: coverage"], 
-        fileSize: 17591040, 
-        fileType: CARTA.FileType.FITS, 
-        shape: [830, 870, 1, 1], NAXIS: 2, 
-        computedEntries: [ 
-            { name: "Name", value: "spire500_ext.fits" },
-            { name: "Shape", value: "[830, 870]" },
-            { name: "Coordinate type", value: "RA---TAN, DEC--TAN" },
-            { name: "Image reference pixels", value: "[861, 976] " },
-            {
-                name: "Image reference coordinates",
-                value: "[107.3046 , -10.6107 ]" },
-            {
-                name: "Image ref coords (coord type)",
-                value: "[107.305 , -10.6107 ]" },
-            { name: "Celestial frame", value: "ICRS, 2000" },
-            { name: "Pixel increment", value: "-0.002 , 0.002 " } ],
-        headerEntries: [ 
-            { name: "NAXIS", value: "2", entryType: 2, numericValue: 2 },
-            { name: "NAXIS1", value: "830", entryType: 2, numericValue: 830 },
-            { name: "NAXIS2", value: "870", entryType: 2, numericValue: 870 },
-            { name: "CRPIX1", value: "861", entryType: 1, numericValue: 861 },
-            { name: "CRPIX2", value: "976", entryType: 1, numericValue: 976 },
-            {
-                name: "CDELT1",
-                value: "-0.00166667",
-                entryType: 1,
-                numericValue: -0.001666666666667 },
-            {
-                name: "CDELT2",
-                value: "0.00166667",
-                entryType: 1,
-                numericValue: 0.001666666666667 },
-            { name: "CTYPE1", value: "RA---TAN" },
-            { name: "CTYPE2", value: "DEC--TAN" },
-            {
-                name: "EQUINOX",
-                value: "2000",
-                entryType: 1,
-                numericValue: 2000 },
-            { name: "CROTA2", value: "0", entryType: 1 },
-            {
-                name: "CRVAL1",
-                value: "107.305",
-                entryType: 1,
-                numericValue: 107.30461727023817 },
-            {
-                name: "CRVAL2",
-                value: "-10.6107",
-                entryType: 1,
-                numericValue: -10.610720896516849 },
-            { name: "RADESYS", value: "ICRS" },
-        ], 
-    },
-
-];
+    filelist: {directory: testSubdirectory},
+    fileInfoGroup: [
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.fits",
+            hdu: "0",
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.image",
+            hdu: "",
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.hdf5",
+            hdu: "0",
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.miriad",
+            hdu: "",
+        },
+        {
+            directory: testSubdirectory,
+            file: "spire500_ext.fits",
+            hdu: "0",
+        },
+    ],
+    fileInfoResGroup: [
+        {
+            success: true,
+            message: "",
+            fileInfo: {
+                name: "M17_SWex.fits",
+                type: CARTA.FileType.FITS,
+                size: 51393600,
+                HDUList: ["0"],
+            },
+            fileInfoExtended: {
+                dimensions: 4,
+                width: 640,
+                height: 800,
+                depth: 25,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [ 
+                    { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
+                    { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
+                    { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
+                    { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
+                    { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
+                    {
+                        name: "BMAJ",
+                        value: "0.000572514",
+                        entryType: 1,
+                        numericValue: 0.0005725136068132 },
+                    {
+                        name: "BMIN",
+                        value: "0.000414239",
+                        entryType: 1,
+                        numericValue: 0.00041423857212070003 },
+                    {
+                        name: "BPA",
+                        value: "-74.6267",
+                        entryType: 1,
+                        numericValue: -74.62673187256 },
+                    { name: "BUNIT", value: "Jy/beam" },
+                    { name: "LONPOLE", value: "180", entryType: 1, numericValue: 180 },
+                    {
+                        name: "LATPOLE",
+                        value: "-16.2028",
+                        entryType: 1,
+                        numericValue: -16.20277777779 },
+                    { name: "CTYPE3", value: "FREQ" },
+                    {
+                        name: "CRVAL3",
+                        value: "8.67514e+10",
+                        entryType: 1,
+                        numericValue: 86751396188.4 },
+                    {
+                        name: "CDELT3",
+                        value: "-244238",
+                        entryType: 1,
+                        numericValue: -244237.7011414 },
+                    { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT3", value: "Hz" },
+                    { name: "CTYPE4", value: "STOKES" },
+                    { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT4" },
+                    {
+                        name: "RESTFRQ",
+                        value: "8.67543e+10",
+                        entryType: 1,
+                        numericValue: 86754290000 },
+                    { name: "VELREF", value: "257", entryType: 2, numericValue: 257 },
+                ],
+                computedEntries: [ 
+                    { name: "Name", value: "M17_SWex.fits" },
+                    { name: "Shape", value: "[640, 800, 25, 1]" },
+                    {
+                        name: "Number of channels",
+                        value: "25",
+                        entryType: 2,
+                        numericValue: 25 },
+                    {
+                        name: "Number of Stokes",
+                        value: "1",
+                        entryType: 2,
+                        numericValue: 1 },
+                    { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
+                    { name: "Image reference pixels", value: "[321, 401] " },
+                    {
+                        name: "Image reference coordinates",
+                        value: "[275.0875 deg, -16.2028 deg]" },
+                    {
+                        name: "Image ref coords (coord type)",
+                        value: "[18:20:21.0000, -016.12.10.0000]" },
+                    { name: "Celestial frame", value: "ICRS" },
+                    { name: "Spectral frame", value: "LSRK" },
+                    { name: "Pixel unit", value: "Jy/beam" },
+                    { name: "Pixel increment", value: "-0.40\", 0.40\"" },
+                    { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } 
+                ],
+            },
+        },
+        {
+            success: true,
+            message: "",
+            fileInfo: {
+                name: "M17_SWex.image",
+                type: CARTA.FileType.CASA,
+                size: 53009869,
+                HDUList: [""],
+            },
+            fileInfoExtended: {
+                dimensions: 4,
+                width: 640,
+                height: 800,
+                depth: 25,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [
+                    { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
+                    { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
+                    { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
+                    { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
+                    { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
+                    {
+                        name: "BMAJ",
+                        value: "0.000572514",
+                        entryType: 1,
+                        numericValue: 0.0005725136068132 },
+                    {
+                        name: "BMIN",
+                        value: "0.000414239",
+                        entryType: 1,
+                        numericValue: 0.0004142385721207 },
+                    {
+                        name: "BPA",
+                        value: "-74.6267",
+                        entryType: 1,
+                        numericValue: -74.6267318725586 },
+                    { name: "BUNIT", value: "Jy/beam" },
+                    { name: "CTYPE3", value: "Frequency" },
+                    {
+                        name: "CRVAL3",
+                        value: "8.67514e+10",
+                        entryType: 1,
+                        numericValue: 86751396188.4 },
+                    {
+                        name: "CDELT3",
+                        value: "-244238",
+                        entryType: 1,
+                        numericValue: -244237.7011414 },
+                    { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT3", value: "Hz" },
+                    { name: "CTYPE4", value: "Stokes" },
+                    { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT4" },
+                    {
+                        name: "RESTFRQ",
+                        value: "8.67543e+10 Hz\n",
+                        entryType: 1,
+                        numericValue: 86754290000 },
+                ],
+                computedEntries: [ 
+                    { name: "Name", value: "M17_SWex.image" },
+                    { name: "Shape", value: "[640, 800, 25, 1]" },
+                    {
+                        name: "Number of channels",
+                        value: "25",
+                        entryType: 2,
+                        numericValue: 25 },
+                    {
+                        name: "Number of Stokes",
+                        value: "1",
+                        entryType: 2,
+                        numericValue: 1 },
+                    { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
+                    { name: "Image reference pixels", value: "[321, 401]" },
+                    {
+                        name: "Image reference coordinates",
+                        value: "[275.088 deg, -16.203 deg]" },
+                    {
+                        name: "Image ref coords (coord type)",
+                        value: "[18:20:21.0000 -016.12.10.0000]" },
+                    { name: "Celestial frame", value: "ICRS, 2000" },
+                    { name: "Spectral frame", value: "LSRK" },
+                    { name: "Pixel unit", value: "Jy/beam" },
+                    { name: "Pixel increment", value: "-0.40\", 0.40\"" },
+                    { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } 
+                ],
+            },
+        },
+        {
+            success: true,
+            message: "",
+            fileInfo: {
+                name: "M17_SWex.hdf5",
+                type: CARTA.FileType.HDF5,
+                size: 112823720,
+                HDUList: ["0"],
+            },
+            fileInfoExtended: {
+                dimensions: 4,
+                width: 640,
+                height: 800,
+                depth: 25,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [
+                    { name: "NAXIS", value: "4" },
+                    { name: "NAXIS1", value: "640" },
+                    { name: "NAXIS2", value: "800" },
+                    { name: "NAXIS3", value: "25" },
+                    { name: "NAXIS4", value: "1" },
+                    { name: "BMAJ", value: "5.725136068132E-04" },
+                    { name: "BMIN", value: "4.142385721207E-04" },
+                    { name: "BPA", value: "-7.462673187256E+01" },
+                    { name: "BUNIT", value: "Jy/beam" },
+                    { name: "LONPOLE", value: "1.800000000000E+02" },
+                    { name: "LATPOLE", value: "-1.620277777779E+01" },
+                    { name: "CTYPE3", value: "FREQ" },
+                    { name: "CRVAL3", value: "8.675139618840E+10" },
+                    { name: "CDELT3", value: "-2.442377011414E+05" },
+                    { name: "CRPIX3", value: "1.000000000000E+00" },
+                    { name: "CUNIT3", value: "Hz" },
+                    { name: "CTYPE4", value: "STOKES" },
+                    { name: "CRVAL4", value: "1.000000000000E+00" },
+                    { name: "CDELT4", value: "1.000000000000E+00" },
+                    { name: "CRPIX4", value: "1.000000000000E+00" },
+                    { name: "CUNIT4" },
+                    { name: "RESTFRQ", value: "8.675429000000E+10" },,
+                    { name: "VELREF", value: "257" },
+                ],
+                computedEntries: [ 
+                    { name: "Name", value: "M17_SWex.hdf5" },
+                    { name: "Shape", value: "[640, 800, 25, 1]" },
+                    {
+                        name: "Number of channels",
+                        value: "25",
+                        entryType: 2,
+                        numericValue: 25 },
+                    {
+                        name: "Number of Stokes",
+                        value: "1",
+                        entryType: 2,
+                        numericValue: 1 },
+                    { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
+                    {
+                        name: "Image reference pixels",
+                        value: "[3.210000000000E+02, 4.010000000000E+02] " },
+                    {
+                        name: "Image reference coordinates",
+                        value: "[275.0875 deg, -16.2028 deg]" },
+                    {
+                        name: "Image ref coords (coord type)",
+                        value: "[18:20:21.0000, -016.12.10.0000]" },
+                    { name: "Celestial frame", value: "ICRS" },
+                    { name: "Spectral frame", value: "LSRK" },
+                    { name: "Pixel unit", value: "Jy/beam" },
+                    { name: "Pixel increment", value: "-0.40\", 0.40\"" },
+                    { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } 
+                ],
+            },
+        },
+        {
+            success: true,
+            message: "",
+            fileInfo: {
+                name: "M17_SWex.miriad",
+                type: CARTA.FileType.MIRIAD,
+                size: 52993642,
+                HDUList: [""],
+            },
+            fileInfoExtended: {
+                dimensions: 4,
+                width: 640,
+                height: 800,
+                depth: 25,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [
+                    { name: "NAXIS", value: "4", entryType: 2, numericValue: 4 },
+                    { name: "NAXIS1", value: "640", entryType: 2, numericValue: 640 },
+                    { name: "NAXIS2", value: "800", entryType: 2, numericValue: 800 },
+                    { name: "NAXIS3", value: "25", entryType: 2, numericValue: 25 },
+                    { name: "NAXIS4", value: "1", entryType: 2, numericValue: 1 },
+                    {
+                        name: "BMAJ",
+                        value: "0.000572514",
+                        entryType: 1,
+                        numericValue: 0.0005725135932445429 },
+                    {
+                        name: "BMIN",
+                        value: "0.000414239",
+                        entryType: 1,
+                        numericValue: 0.00041423858135383447 },
+                    {
+                        name: "BPA",
+                        value: "-74.6267",
+                        entryType: 1,
+                        numericValue: -74.6267318725586 },
+                    { name: "BUNIT", value: "Jy/beam" },
+                    { name: "CTYPE3", value: "Frequency" },
+                    {
+                        name: "CRVAL3",
+                        value: "8.67514e+10",
+                        entryType: 1,
+                        numericValue: 86751396188.40004 },
+                    {
+                        name: "CDELT3",
+                        value: "-244238",
+                        entryType: 1,
+                        numericValue: -244237.7011414 },
+                    { name: "CRPIX3", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT3", value: "Hz" },
+                    { name: "CTYPE4", value: "Stokes" },
+                    { name: "CRVAL4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CDELT4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CRPIX4", value: "1", entryType: 1, numericValue: 1 },
+                    { name: "CUNIT4" },
+                    {
+                        name: "RESTFRQ",
+                        value: "8.67543e+10 Hz\n",
+                        entryType: 1,
+                        numericValue: 86754290000.00003 
+                    },
+                ],
+                computedEntries: [ 
+                    { name: "Name", value: "M17_SWex.miriad" },
+                    { name: "Shape", value: "[640, 800, 25, 1]" },
+                    {
+                        name: "Number of channels",
+                        value: "25",
+                        entryType: 2,
+                        numericValue: 25 },
+                    {
+                        name: "Number of Stokes",
+                        value: "1",
+                        entryType: 2,
+                        numericValue: 1 },
+                    { name: "Coordinate type", value: "RA---SIN, DEC--SIN" },
+                    { name: "Image reference pixels", value: "[321, 401]" },
+                    {
+                        name: "Image reference coordinates",
+                        value: "[275.088 deg, -16.203 deg]" },
+                    {
+                        name: "Image ref coords (coord type)",
+                        value: "[18:20:21.0000 -016.12.10.0000]" },
+                    { name: "Celestial frame", value: "FK5, J2000" },
+                    { name: "Spectral frame", value: "BARYCENT" },
+                    { name: "Pixel unit", value: "Jy/beam" },
+                    { name: "Pixel increment", value: "-0.40\", 0.40\"" },
+                    { name: "Restoring beam", value: "2.06\" X 1.49\", -74.6267 deg" } 
+                ],
+            },
+        },
+        {
+            success: true,
+            message: "",
+            fileInfo: {
+                name: "spire500_ext.fits",
+                type: CARTA.FileType.FITS,
+                size: 17591040,
+                HDUList: ["1 ExtName: image", "6 ExtName: error", "7 ExtName: coverage"],
+            },
+            fileInfoExtended: {
+                dimensions: 2,
+                width: 830,
+                height: 870,
+                depth: 1,
+                stokes: 1,
+                stokesVals: [""],
+                headerEntries: [
+                    { name: "NAXIS", value: "2", entryType: 2, numericValue: 2 },
+                    { name: "NAXIS1", value: "830", entryType: 2, numericValue: 830 },
+                    { name: "NAXIS2", value: "870", entryType: 2, numericValue: 870 },
+                    { name: "CRPIX1", value: "861", entryType: 1, numericValue: 861 },
+                    { name: "CRPIX2", value: "976", entryType: 1, numericValue: 976 },
+                    {
+                        name: "CDELT1",
+                        value: "-0.00166667",
+                        entryType: 1,
+                        numericValue: -0.001666666666667 },
+                    {
+                        name: "CDELT2",
+                        value: "0.00166667",
+                        entryType: 1,
+                        numericValue: 0.001666666666667 },
+                    { name: "CTYPE1", value: "RA---TAN" },
+                    { name: "CTYPE2", value: "DEC--TAN" },
+                    {
+                        name: "EQUINOX",
+                        value: "2000",
+                        entryType: 1,
+                        numericValue: 2000 },
+                    { name: "CROTA2", value: "0", entryType: 1 },
+                    {
+                        name: "CRVAL1",
+                        value: "107.305",
+                        entryType: 1,
+                        numericValue: 107.30461727023817 },
+                    {
+                        name: "CRVAL2",
+                        value: "-10.6107",
+                        entryType: 1,
+                        numericValue: -10.610720896516849 },
+                    { name: "RADESYS", value: "ICRS" },
+                ],
+                computedEntries: [ 
+                    { name: "Name", value: "spire500_ext.fits" },
+                    { name: "Shape", value: "[830, 870]" },
+                    { name: "Coordinate type", value: "RA---TAN, DEC--TAN" },
+                    { name: "Image reference pixels", value: "[861, 976] " },
+                    {
+                        name: "Image reference coordinates",
+                        value: "[107.3046 , -10.6107 ]" },
+                    {
+                        name: "Image ref coords (coord type)",
+                        value: "[107.305 , -10.6107 ]" },
+                    { name: "Celestial frame", value: "ICRS, 2000" },
+                    { name: "Pixel increment", value: "-0.002 , 0.002 " }
+                ],
+            },
+        },
+    ],
+}
 
 describe("FILEINFO test: Testing if info of an image file is correctly delivered by the backend", () => {   
     let Connection: WebSocket;
@@ -390,126 +478,93 @@ describe("FILEINFO test: Testing if info of an image file is correctly delivered
         Connection.binaryType = "arraybuffer";
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
-            await Utility.setEvent(this, CARTA.RegisterViewer, 
-                {
-                    sessionId: 0, 
-                    apiKey: "",
-                }
-            );
-            await new Promise( resolve => { 
-                Utility.getEvent(this, CARTA.RegisterViewerAck, 
-                    RegisterViewerAck => {
-                        expect(RegisterViewerAck.success).toBe(true);
-                        resolve();           
-                    }
-                );
-            });
+            await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
             done();
         }
     }, connectTimeout);
 
-    describe(`Go to "${testSubdirectoryName}" folder`, 
+    describe(`Go to "${testSubdirectory}" folder`, 
     () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, CARTA.FileListRequest, 
-                {
-                    directory: testSubdirectoryName,
-                }
-            );
-            await new Promise( resolve => {
-                Utility.getEvent(Connection, CARTA.FileListResponse, 
-                    FileListResponseBase => {
-                        expect(FileListResponseBase.success).toBe(true);
-                        resolve();
-                    }
-                );                
-            });
+            await Utility.setEventAsync(Connection, CARTA.FileListRequest, assertItem.filelist);
+            await Utility.getEventAsync(Connection, CARTA.FileListResponse);
         }, listFileTimeout);
         
-        imageAssertItems.map( function(item: ImageAssertItem) {
-
-            describe(`query the info of file : ${item.fileName}`, () => {
+        assertItem.fileInfoResGroup.map( (fileInfoRes: CARTA.IFileInfoResponse, index: number) => {
+            describe(`query the info of file : ${assertItem.fileInfoGroup[index].file}`, () => {
                 let FileInfoResponseTemp: CARTA.FileInfoResponse;
                 test(`FILE_INFO_RESPONSE should arrive within ${openFileTimeout} ms".`, async () => {
-                    await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
-                        {
-                            directory: testSubdirectoryName, 
-                            file: item.fileName, 
-                            hdu: item.hdu,
-                        }
-                    );
-                    await new Promise( resolve => {
-                        Utility.getEvent(Connection, CARTA.FileInfoResponse, 
-                            (FileInfoResponse: CARTA.FileInfoResponse) => {
-                                FileInfoResponseTemp = FileInfoResponse;
-                                resolve();
-                            }
-                        );                
-                    });                                                 
+                    await Utility.setEventAsync(Connection, CARTA.FileInfoRequest, assertItem.fileInfoGroup[index]);
+                    await Utility.getEventAsync(Connection, CARTA.FileInfoResponse,  
+                        (FileInfoResponse: CARTA.FileInfoResponse, resolve) => {
+                            FileInfoResponseTemp = FileInfoResponse;
+                            resolve();
+                        });                                         
                 }, openFileTimeout);
 
                 test("FILE_INFO_RESPONSE.success = true", () => {
                     expect(FileInfoResponseTemp.success).toBe(true);
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info.HDU_List = [${item.HDUList}]`, () => {
-                    expect(FileInfoResponseTemp.fileInfo.HDUList.map(f => f = f.trim())).toEqual(item.HDUList.map(f => f = f.trim()));
+                test(`FILE_INFO_RESPONSE.file_info.HDU_List = [${fileInfoRes.fileInfo.HDUList}]`, () => {
+                    expect(FileInfoResponseTemp.fileInfo.HDUList.map(f => f = f.trim())).toEqual(fileInfoRes.fileInfo.HDUList.map(f => f = f.trim()));
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info.name = "${item.fileName}"`, () => {
-                    expect(FileInfoResponseTemp.fileInfo.name).toBe(item.fileName);
+                test(`FILE_INFO_RESPONSE.file_info.name = "${fileInfoRes.fileInfo.name}"`, () => {
+                    expect(FileInfoResponseTemp.fileInfo.name).toEqual(fileInfoRes.fileInfo.name);
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info.size = ${item.fileSize}`, () => {
-                    expect(FileInfoResponseTemp.fileInfo.size.toString()).toEqual(item.fileSize.toString());
+                test(`FILE_INFO_RESPONSE.file_info.size = ${fileInfoRes.fileInfo.size}`, () => {
+                    expect(FileInfoResponseTemp.fileInfo.size.toString()).toEqual(fileInfoRes.fileInfo.size.toString());
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info.type = ${CARTA.FileType[item.fileType]}`, () => {
-                    expect(FileInfoResponseTemp.fileInfo.type).toBe(item.fileType);
+                test(`FILE_INFO_RESPONSE.file_info.type = ${CARTA.FileType[fileInfoRes.fileInfo.type]}`, () => {
+                    expect(FileInfoResponseTemp.fileInfo.type).toBe(fileInfoRes.fileInfo.type);
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info_extended.dimensions = ${item.NAXIS}`, () => {
-                    expect(FileInfoResponseTemp.fileInfoExtended.dimensions).toEqual(item.NAXIS);
+                test(`FILE_INFO_RESPONSE.file_info_extended.dimensions = ${fileInfoRes.fileInfoExtended.dimensions}`, () => {
+                    expect(FileInfoResponseTemp.fileInfoExtended.dimensions).toEqual(fileInfoRes.fileInfoExtended.dimensions);
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info_extended.width = ${item.shape[0]}`, () => {
-                    expect(FileInfoResponseTemp.fileInfoExtended.width).toEqual(item.shape[0]);
+                test(`FILE_INFO_RESPONSE.file_info_extended.width = ${fileInfoRes.fileInfoExtended.width}`, () => {
+                    expect(FileInfoResponseTemp.fileInfoExtended.width).toEqual(fileInfoRes.fileInfoExtended.width);
                 });
 
-                test(`FILE_INFO_RESPONSE.file_info_extended.height = ${item.shape[1]}`, () => {
-                    expect(FileInfoResponseTemp.fileInfoExtended.height).toEqual(item.shape[1]);
+                test(`FILE_INFO_RESPONSE.file_info_extended.height = ${fileInfoRes.fileInfoExtended.height}`, () => {
+                    expect(FileInfoResponseTemp.fileInfoExtended.height).toEqual(fileInfoRes.fileInfoExtended.height);
                 });
 
-                if (item.NAXIS > 2) {
-                    test(`FILE_INFO_RESPONSE.file_info_extended.depth = ${item.shape[2]}`, () => {
-                        expect(FileInfoResponseTemp.fileInfoExtended.depth).toEqual(item.shape[2]);
+                if (fileInfoRes.fileInfoExtended.dimensions > 2) {
+                    test(`FILE_INFO_RESPONSE.file_info_extended.depth = ${fileInfoRes.fileInfoExtended.depth}`, () => {
+                        expect(FileInfoResponseTemp.fileInfoExtended.depth).toEqual(fileInfoRes.fileInfoExtended.depth);
                     });
                 }
 
-                if (item.NAXIS > 3) {
-                    test(`FILE_INFO_RESPONSE.file_info_extended.stokes = ${item.shape[3]}`, () => {
-                        expect(FileInfoResponseTemp.fileInfoExtended.stokes).toEqual(item.shape[3]);
+                if (fileInfoRes.fileInfoExtended.dimensions > 3) {
+                    test(`FILE_INFO_RESPONSE.file_info_extended.stokes = ${fileInfoRes.fileInfoExtended.stokes}`, () => {
+                        expect(FileInfoResponseTemp.fileInfoExtended.stokes).toEqual(fileInfoRes.fileInfoExtended.stokes);
                     });
                 }
 
-                test(`FILE_INFO_RESPONSE.file_info_extended.stokes_vals = [""]`, () => {
-                    expect(FileInfoResponseTemp.fileInfoExtended.stokesVals).toEqual([""]);
+                test(`FILE_INFO_RESPONSE.file_info_extended.stokes_vals = ${fileInfoRes.fileInfoExtended.stokesVals}`, () => {
+                    expect(FileInfoResponseTemp.fileInfoExtended.stokesVals).toEqual(fileInfoRes.fileInfoExtended.stokesVals);
                 });
 
                 test(`assert FILE_INFO_RESPONSE.file_info_extended.computed_entries`, () => {
-                    item.computedEntries.map( (entry: CARTA.IHeaderEntry) => {
+                    fileInfoRes.fileInfoExtended.computedEntries.map( (entry: CARTA.IHeaderEntry) => {
                         expect(FileInfoResponseTemp.fileInfoExtended.computedEntries).toContainEqual(entry);
                     });
                 });
                 
                 test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {
-                    item.headerEntries.map( (entry: CARTA.IHeaderEntry) => {
+                    fileInfoRes.fileInfoExtended.headerEntries.map( (entry: CARTA.IHeaderEntry) => {
                         expect(FileInfoResponseTemp.fileInfoExtended.headerEntries).toContainEqual(entry);
                     });
                 });
 
-            }); // describe
-        }); // map
+            }); 
+        });
 
     });
 
@@ -526,61 +581,44 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
         Connection.binaryType = "arraybuffer";
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
-            await Utility.setEvent(this, CARTA.RegisterViewer, 
+            await Utility.setEventAsync(this, CARTA.RegisterViewer, 
                 {
                     sessionId: 0, 
                     apiKey: "",
                 }
             );
-            await new Promise( resolve => { 
-                Utility.getEvent(this, CARTA.RegisterViewerAck, 
-                    RegisterViewerAck => {
-                        expect(RegisterViewerAck.success).toBe(true);
-                        resolve();           
-                    }
-                );
-            });
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
             done();
         }
     }, connectTimeout);
 
-    describe(`Go to "${testSubdirectoryName}" folder`, () => {
+    describe(`Go to "${testSubdirectory}" folder`, () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, CARTA.FileListRequest, 
+            await Utility.setEventAsync(Connection, CARTA.FileListRequest, 
                 {
-                    directory: testSubdirectoryName,
+                    directory: testSubdirectory,
                 }
             );
-            await new Promise( resolve => {
-                Utility.getEvent(Connection, CARTA.FileListResponse, 
-                    FileListResponseBase => {
-                        expect(FileListResponseBase.success).toBe(true);
-                        resolve();
-                    }
-                );                
-            });
+            await Utility.getEventAsync(Connection, CARTA.FileListResponse);
         }, listFileTimeout);
         
-        [ "no_such_file.image", "broken_header.miriad"].map( function(fileName: string) {
-
+        [ "no_such_file.image", "broken_header.miriad"].map( (fileName: string) => {
             describe(`query the info of file : ${fileName}`, () => {
                 let FileInfoResponseTemp: CARTA.FileInfoResponse;
                 test(`FILE_INFO_RESPONSE should arrive within ${openFileTimeout} ms".`, async () => {
                     await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
                         {
-                            directory: testSubdirectoryName, 
+                            directory: testSubdirectory, 
                             file: fileName, 
                             hdu: "",
                         }
                     );
-                    await new Promise( resolve => {
-                        Utility.getEvent(Connection, CARTA.FileInfoResponse, 
-                            (FileInfoResponse: CARTA.FileInfoResponse) => {
-                                FileInfoResponseTemp = FileInfoResponse;
-                                resolve();
-                            }
-                        );                
-                    });                                                 
+                    await Utility.getEventAsync(Connection, CARTA.FileInfoResponse,  
+                        (FileInfoResponse: CARTA.FileInfoResponse, resolve) => {
+                            FileInfoResponseTemp = FileInfoResponse;
+                            resolve();
+                        }
+                    );                                         
                 }, openFileTimeout);
 
                 test("FILE_INFO_RESPONSE.success = false", () => {
@@ -592,9 +630,8 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
                     expect(FileInfoResponseTemp.message).not.toBe("");
                     console.log(`Error message from reading "${fileName}": ${FileInfoResponseTemp.message}`);
                 });
-            }); // describe
-
-        }); // map
+            });
+        });
     });
 
     afterAll( () => {

--- a/src/test/FILEINFO.test.ts
+++ b/src/test/FILEINFO.test.ts
@@ -606,7 +606,7 @@ describe("FILEINFO_EXCEPTIONS test: Testing error handle of file info generation
             describe(`query the info of file : ${fileName}`, () => {
                 let FileInfoResponseTemp: CARTA.FileInfoResponse;
                 test(`FILE_INFO_RESPONSE should arrive within ${openFileTimeout} ms".`, async () => {
-                    await Utility.setEvent(Connection, CARTA.FileInfoRequest, 
+                    await Utility.setEventAsync(Connection, CARTA.FileInfoRequest, 
                         {
                             directory: testSubdirectory, 
                             file: fileName, 

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -4,6 +4,7 @@ import config from "./config.json";
 let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
+let fileListTimeout = config.timeout.listFile;
 interface AssertItem {
     register: CARTA.IRegisterViewer;
     filelist: CARTA.IFileListRequest;
@@ -88,7 +89,7 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
 
     describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
         let FileListResponseTemp: CARTA.FileListResponse;
-        test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, async () => {
+        test(`should get "FILE_LIST_RESPONSE" within ${fileListTimeout} ms.`, async () => {
             await Utility.setEventAsync(Connection, CARTA.FileListRequest, assertItem.filelist);
             await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
                 (FileListResponse: CARTA.FileListResponse, resolve) => {
@@ -96,7 +97,7 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
                     resolve();
                 }
             );
-        }, connectTimeout);
+        }, fileListTimeout);
 
         test(`FILE_LIST_RESPONSE.success = ${assertItem.fileListResponse.success}`, () => {
             expect(FileListResponseTemp.success).toBe(assertItem.fileListResponse.success);

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -81,7 +81,7 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
             await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
             done();
         }
     }, connectTimeout);
@@ -91,8 +91,9 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
         test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, async () => {
             await Utility.setEventAsync(Connection, CARTA.FileListRequest, assertItem.filelist);
             await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
-                (FileListResponse: CARTA.FileListResponse) => {
+                (FileListResponse: CARTA.FileListResponse, resolve) => {
                     FileListResponseTemp = FileListResponse;
+                    resolve();
                 }
             );
         }, connectTimeout);

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -82,7 +82,7 @@ describe("FILETYPE_PARSER test: Testing if all supported image types can be dete
         Connection.onopen = OnOpen;
         async function OnOpen (this: WebSocket, ev: Event) {
             await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-            await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
             done();
         }
     }, connectTimeout);

--- a/src/test/GET_FILELIST.test.ts
+++ b/src/test/GET_FILELIST.test.ts
@@ -48,7 +48,7 @@ describe("GET_FILELIST_DEFAULT_PATH tests: Testing generation of a file list at 
             async function OnOpen (this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-                await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
+                await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
                 done();
             }
         }, connectTimeout);
@@ -112,7 +112,7 @@ describe("GET_FILELIST_UNKNOWN_PATH tests: Testing error handle of file list gen
             Connection.onopen = OnOpen;
             async function OnOpen (this: WebSocket, ev: Event) {
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-                await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
+                await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
                 done();
             }
         }, connectTimeout);

--- a/src/test/GET_FILELIST.test.ts
+++ b/src/test/GET_FILELIST.test.ts
@@ -5,6 +5,7 @@ let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.directory;
 let expectBasePath = config.path.base;
 let connectTimeout = config.timeout.connection;
+let fileListTimeout = config.timeout.listFile;
 interface AssertItem {
     register: CARTA.IRegisterViewer;
     filelistGroup: CARTA.IFileListRequest[];
@@ -55,7 +56,7 @@ describe("GET_FILELIST_DEFAULT_PATH tests: Testing generation of a file list at 
         assertItem.filelistGroup.map( (filelist, index) => {
             describe(`access folder "${filelist.directory}"`, () => {
                 let FileListResponseTemp: CARTA.FileListResponse;
-                test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, async () => {
+                test(`should get "FILE_LIST_RESPONSE" within ${fileListTimeout} ms.`, async () => {
                     await Utility.setEventAsync(Connection, CARTA.FileListRequest, filelist);
                     await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
                         (FileListResponse: CARTA.FileListResponse, resolve) => {
@@ -63,7 +64,7 @@ describe("GET_FILELIST_DEFAULT_PATH tests: Testing generation of a file list at 
                             resolve();
                         }
                     );
-                }, connectTimeout);
+                }, fileListTimeout);
             
                 test(`FILE_LIST_RESPONSE.success = ${assertItem.fileListResponseGroup[index].success}`, () => {
                     expect(FileListResponseTemp.success).toBe(assertItem.fileListResponseGroup[index].success);
@@ -118,7 +119,7 @@ describe("GET_FILELIST_UNKNOWN_PATH tests: Testing error handle of file list gen
     
         describe(`access folder "/unknown/path"`, () => {
             let FileListResponseTemp: CARTA.FileListResponse;
-            test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, async () => {
+            test(`should get "FILE_LIST_RESPONSE" within ${fileListTimeout} ms.`, async () => {
                 await Utility.setEventAsync(Connection, CARTA.FileListRequest, 
                     {
                         directory: "/unknown/path",
@@ -130,7 +131,7 @@ describe("GET_FILELIST_UNKNOWN_PATH tests: Testing error handle of file list gen
                         resolve();
                     }
                 );
-            }, connectTimeout);
+            }, fileListTimeout);
         
             test("FILE_LIST_RESPONSE.success == False", () => {
                 expect(FileListResponseTemp.success).toBe(false);

--- a/src/test/GET_FILELIST.test.ts
+++ b/src/test/GET_FILELIST.test.ts
@@ -47,7 +47,7 @@ describe("GET_FILELIST_DEFAULT_PATH tests: Testing generation of a file list at 
             async function OnOpen (this: WebSocket, ev: Event) {
                 expect(this.readyState).toBe(WebSocket.OPEN);
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-                await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
+                await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
                 done();
             }
         }, connectTimeout);
@@ -58,8 +58,9 @@ describe("GET_FILELIST_DEFAULT_PATH tests: Testing generation of a file list at 
                 test(`should get "FILE_LIST_RESPONSE" within ${connectTimeout} ms.`, async () => {
                     await Utility.setEventAsync(Connection, CARTA.FileListRequest, filelist);
                     await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
-                        (FileListResponse: CARTA.FileListResponse) => {
+                        (FileListResponse: CARTA.FileListResponse, resolve) => {
                             FileListResponseTemp = FileListResponse;
+                            resolve();
                         }
                     );
                 }, connectTimeout);
@@ -110,7 +111,7 @@ describe("GET_FILELIST_UNKNOWN_PATH tests: Testing error handle of file list gen
             Connection.onopen = OnOpen;
             async function OnOpen (this: WebSocket, ev: Event) {
                 await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
-                await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
+                await Utility.getEventAsync(this, CARTA.RegisterViewerAck, (ack, resolve) => resolve());
                 done();
             }
         }, connectTimeout);
@@ -124,8 +125,9 @@ describe("GET_FILELIST_UNKNOWN_PATH tests: Testing error handle of file list gen
                     }
                 );
                 await Utility.getEventAsync(Connection, CARTA.FileListResponse, 
-                    (FileListResponse: CARTA.FileListResponse) => {
+                    (FileListResponse: CARTA.FileListResponse, resolve) => {
                         FileListResponseTemp = FileListResponse;
+                        resolve();
                     }
                 );
             }, connectTimeout);

--- a/src/test/OPEN_IMAGE_APPEND.test.ts
+++ b/src/test/OPEN_IMAGE_APPEND.test.ts
@@ -119,7 +119,7 @@ describe("OPEN_IMAGE_APPEND test: Testing the case of opening multiple images on
 
     describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, CARTA.CloseFile, {fileId: -1});
+            await Utility.setEventAsync(Connection, CARTA.CloseFile, {fileId: -1});
         }, connectTimeout);
 
         assertItem.fileOpenAckGroup.map( (fileOpenAck: CARTA.IOpenFileAck, index) => {

--- a/src/test/OPEN_IMAGE_APPEND.test.ts
+++ b/src/test/OPEN_IMAGE_APPEND.test.ts
@@ -2,23 +2,105 @@ import {CARTA} from "carta-protobuf";
 import * as Utility from "./testUtilityFunction";
 import config from "./config.json";
 let testServerUrl: string = config.serverURL;
-let testSubdirectoryName: string = config.path.QA;
+let testSubdirectory: string = config.path.QA;
 let connectTimeout: number = config.timeout.connection;
 let openFileTimeout: number = config.timeout.openFile;
 let readFileTimeout: number = config.timeout.readFile;
-type AssertItem = [
-    string,
-    number,
-    string,
-    {xMin: number, xMax: number, yMin: number, yMax: number},
-    number    
-]
-let assertItems: AssertItem[] = [
-    [   "M17_SWex.fits",    0,  "0",    {xMin: 0, xMax: 640, yMin: 0, yMax: 800},   1],
-    [   "M17_SWex.hdf5",    1,  "0",    {xMin: 0, xMax: 640, yMin: 0, yMax: 800},   2],
-    [   "M17_SWex.image",   2,  "",     {xMin: 0, xMax: 640, yMin: 0, yMax: 800},   4],
-    [   "M17_SWex.miriad",  3,  "",     {xMin: 0, xMax: 640, yMin: 0, yMax: 800},   8],
-];
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpenGroup: CARTA.IOpenFile[];
+    fileOpenAckGroup: CARTA.IOpenFileAck[];
+    setImageViewGroup: CARTA.ISetImageView[],
+    rasterImageDataGroup: CARTA.IRasterImageData[],
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+    },
+    filelist: {directory: testSubdirectory},    
+    fileOpenGroup: [
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.fits",
+            hdu: "0",
+            fileId: 0,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.hdf5",
+            hdu: "0",
+            fileId: 1,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.image",
+            hdu: "0",
+            fileId: 2,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "M17_SWex.miriad",
+            hdu: "0",
+            fileId: 3,
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    fileOpenAckGroup: [
+        {
+            success: true,
+            fileId: 0,
+        },
+        {
+            success: true,
+            fileId: 1,
+        },
+        {
+            success: true,
+            fileId: 2,
+        },
+        {
+            success: true,
+            fileId: 3,
+        },
+    ],
+    setImageViewGroup: [
+        {
+            fileId: 0,
+            imageBounds: {xMin: 0, xMax: 640, yMin: 0, yMax: 800},
+            mip: 1,
+            compressionType: CARTA.CompressionType.NONE,
+        },
+        {
+            fileId: 1,
+            imageBounds: {xMin: 0, xMax: 640, yMin: 0, yMax: 800},
+            mip: 2,
+            compressionType: CARTA.CompressionType.NONE,
+        },
+        {
+            fileId: 2,
+            imageBounds: {xMin: 0, xMax: 640, yMin: 0, yMax: 800},
+            mip: 4,
+            compressionType: CARTA.CompressionType.NONE,
+        },
+        {
+            fileId: 3,
+            imageBounds: {xMin: 0, xMax: 640, yMin: 0, yMax: 800},
+            mip: 8,
+            compressionType: CARTA.CompressionType.NONE,
+        },
+    ],
+    rasterImageDataGroup: [
+        {fileId: 0},
+        {fileId: 1},
+        {fileId: 2},
+        {fileId: 3},
+    ],
+}
 
 describe("OPEN_IMAGE_APPEND test: Testing the case of opening multiple images one by one without closing former ones", () => {   
     let Connection: WebSocket;
@@ -29,93 +111,55 @@ describe("OPEN_IMAGE_APPEND test: Testing the case of opening multiple images on
         Connection.onopen = OnOpen;
 
         async function OnOpen (this: WebSocket, ev: Event) {
-            await Utility.setEvent(this, CARTA.RegisterViewer, 
-                {
-                    sessionId: 0, 
-                    apiKey: ""
-                }
-            );
-            await new Promise( resolve => { 
-                Utility.getEvent(this, CARTA.RegisterViewerAck, 
-                    RegisterViewerAck => {
-                        expect(RegisterViewerAck.success).toBe(true);
-                        resolve();           
-                    }
-                );
-            });
-            await done();   
+            await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.register);
+            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
+            done();   
         }
     }, connectTimeout);
 
-    describe(`Go to "${testSubdirectoryName}" folder`, () => {
+    describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
         beforeAll( async () => {
-            await Utility.setEvent(Connection, CARTA.CloseFile, 
-                {
-                    fileId: -1,
-                }
-            );
+            await Utility.setEvent(Connection, CARTA.CloseFile, {fileId: -1});
         }, connectTimeout);
 
-        assertItems.map( function ([fileName, fileId, hdu, imageBounds, mip]: AssertItem) {
+        assertItem.fileOpenAckGroup.map( (fileOpenAck: CARTA.IOpenFileAck, index) => {
                     
-            describe(`open the file "${fileName}"`, () => {
+            describe(`open the file "${assertItem.fileOpenGroup[index].file}"`, () => {
                 let OpenFileAckTemp: CARTA.OpenFileAck;
                 test(`OPEN_FILE_ACK should arrive within ${openFileTimeout} ms`, async () => {
-                    await Utility.setEvent(Connection, CARTA.OpenFile, 
-                        {
-                            directory: testSubdirectoryName, 
-                            file: fileName, 
-                            hdu: hdu, 
-                            fileId: fileId, 
-                            renderMode: CARTA.RenderMode.RASTER,
+                    await Utility.setEventAsync(Connection, CARTA.OpenFile, assertItem.fileOpenGroup[index]);
+                    await Utility.getEventAsync(Connection, CARTA.OpenFileAck,  
+                        (OpenFileAck: CARTA.OpenFileAck, resolve) => {
+                            OpenFileAckTemp = OpenFileAck;
+                            resolve();
                         }
                     );
-                    await new Promise( resolve => {
-                        Utility.getEvent(Connection, CARTA.OpenFileAck, 
-                            (OpenFileAck: CARTA.OpenFileAck) => {
-                                OpenFileAckTemp = OpenFileAck;
-                                resolve();
-                            }
-                        );
-                        
-                    });
                 }, openFileTimeout);
 
-                test("OPEN_FILE_ACK.success = true", () => {
-                    expect(OpenFileAckTemp.success).toBe(true);
+                test(`OPEN_FILE_ACK.success = $${fileOpenAck.success}`, () => {
+                    expect(OpenFileAckTemp.success).toBe(fileOpenAck.success);
                 });
 
-                test(`OPEN_FILE_ACK.file_id = ${fileId}`, () => {                    
-                    expect(OpenFileAckTemp.fileId).toEqual(fileId);
+                test(`OPEN_FILE_ACK.file_id = ${fileOpenAck.fileId}`, () => {                    
+                    expect(OpenFileAckTemp.fileId).toEqual(fileOpenAck.fileId);
                 });
 
             });
 
-            describe(`set image view for the file "${fileName}"`, () => {
+            describe(`set image view for the file "${assertItem.fileOpenGroup[index].file}"`, () => {
                 let RasterImageDataTemp: CARTA.RasterImageData;
                 test(`RASTER_IMAGE_DATA should arrive within ${readFileTimeout} ms`, async () => {
-                    await Utility.setEvent(Connection, CARTA.SetImageView, 
-                        {
-                            fileId: fileId, 
-                            imageBounds: imageBounds, 
-                            mip: mip, 
-                            compressionType: CARTA.CompressionType.NONE,
-                            compressionQuality: 0, 
-                            numSubsets: 0,
+                    await Utility.setEventAsync(Connection, CARTA.SetImageView, assertItem.setImageViewGroup[index]);
+                    await Utility.getEventAsync(Connection, CARTA.RasterImageData,  
+                        (RasterImageData: CARTA.RasterImageData, resolve) => {
+                            RasterImageDataTemp = RasterImageData;
+                            resolve();
                         }
                     );
-                    await new Promise( resolve => {
-                        Utility.getEvent(Connection, CARTA.RasterImageData, 
-                            (RasterImageData: CARTA.RasterImageData) => {
-                                RasterImageDataTemp = RasterImageData;
-                                resolve();
-                            }
-                        );                
-                    });
                 }, readFileTimeout);
 
-                test(`RASTER_IMAGE_DATA.file_id = ${fileId}`, () => {
-                    expect(RasterImageDataTemp.fileId).toEqual(fileId);
+                test(`RASTER_IMAGE_DATA.file_id = ${assertItem.rasterImageDataGroup[index].fileId}`, () => {
+                    expect(RasterImageDataTemp.fileId).toEqual(assertItem.rasterImageDataGroup[index].fileId);
                 });
 
             });

--- a/src/test/testUtilityFunction.ts
+++ b/src/test/testUtilityFunction.ts
@@ -120,7 +120,7 @@ export function getEvent(
 export function getEventAsync(
     connection: WebSocket, 
     cartaType: any, 
-    promiseToDo?: (DataMessage: any, resolve: {} | PromiseLike<{}>, reject?: {} | PromiseLike<{}>) => void,
+    promiseToDo?: (DataMessage: any, resolve: any, reject?: any) => void,
 ) {
     return new Promise( (resolve, reject) =>
         connection.onmessage = async (messageEvent: MessageEvent) => {


### PR DESCRIPTION
Enhance Utility.setEvent and Utility.getEvent to setEventAsync and getEventAsync.
Apply these functions to refactor the tests: ACCESS_CARTA_DEFAULT, ACCESS_CARTA_UNKNOWN_SESSION, ACCESS_CARTA_APIKEY, ACCESS_CARTA_UNKNOWN_APIKEY, GET_FILELIST, FILETYPE_PARSER, FILEINFO, OPEN_IMAGE_APPEND, & CHECK_RASTER_IMAGE_DATA_noCompression.