### PR TITLE
Minor fixed the test: region import 

### DIFF
--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -215,8 +215,7 @@ describe("CASA_REGION_IMPORT_EXPORT test: Testing import/export of CASA region f
             assertItem.importRegionAck.regions.map( (region, index) => {
                 test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region.regionId}, Type:${CARTA.RegionType[region.regionInfo.regionType]}"`, () => {
                     expect(importRegionAck.regions[index].regionId).toEqual(region.regionId);
-                    if(region.regionInfo.regionType)
-                        expect(importRegionAck.regions[index].regionInfo.regionType).toEqual(region.regionInfo.regionType);
+                    expect(importRegionAck.regions[index].regionInfo.regionType).toEqual(region.regionInfo.regionType);
                     if(region.regionInfo.rotation)
                         expect(importRegionAck.regions[index].regionInfo.rotation).toEqual(region.regionInfo.rotation);
                     expect(importRegionAck.regions[index].regionInfo.controlPoints).toEqual(region.regionInfo.controlPoints);   

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -75,7 +75,7 @@ let assertItem: AssertItem = {
                 {
                     regionId: 4, 
                     regionInfo: {
-                        regionType: CARTA.RegionType.ELLIPSE,
+                        regionType: CARTA.RegionType.RECTANGLE,
                         rotation: 45,
                         controlPoints: [{x: -120.6, y: 251.9}, {x: 173.5, y: 44.0}],
                     },
@@ -114,7 +114,7 @@ let assertItem: AssertItem = {
                 {
                     regionId: 9, 
                     regionInfo: {
-                        regionType: CARTA.RegionType.RECTANGLE,
+                        regionType: CARTA.RegionType.POINT,
                         controlPoints: [{x: 175.81072998046875, y: 591.085693359375}],
                     },
                 },
@@ -200,7 +200,7 @@ let assertItem: AssertItem = {
                 {
                     regionId: 20, 
                     regionInfo: {
-                        regionType: CARTA.RegionType.ELLIPSE,
+                        regionType: CARTA.RegionType.RECTANGLE,
                         rotation: 45,
                         controlPoints: [{x: -120.6, y: 251.9}, {x: 173.5, y: 44.0}],
                     },
@@ -238,7 +238,7 @@ let assertItem: AssertItem = {
                 {
                     regionId: 25, 
                     regionInfo: {
-                        regionType: CARTA.RegionType.RECTANGLE,
+                        regionType: CARTA.RegionType.POINT,
                         controlPoints: [{x: 175.81072998046875, y: 591.085693359375}],
                     },
                 },

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -340,8 +340,7 @@ describe("CASA_REGION_IMPORT_INTERNAL test: Testing import of CASA region files 
                 regionAck.regions.map( (region, index) => {
                     test(`IMPORT_REGION_ACK.region[${index}] = "Id:${region.regionId}, Type:${CARTA.RegionType[region.regionInfo.regionType]}"`, () => {
                         expect(importRegionAck.regions[index].regionId).toEqual(region.regionId);
-                        if(region.regionInfo.regionType)
-                            expect(importRegionAck.regions[index].regionInfo.regionType).toEqual(region.regionInfo.regionType);
+                        expect(importRegionAck.regions[index].regionInfo.regionType).toEqual(region.regionInfo.regionType);
                         if(region.regionInfo.rotation)
                             expect(importRegionAck.regions[index].regionInfo.rotation).toEqual(region.regionInfo.rotation);
                         expect(importRegionAck.regions[index].regionInfo.controlPoints).toEqual(region.regionInfo.controlPoints);


### PR DESCRIPTION
Let the test to exam items one-by-one int the IMPORT_REGION_ACK.region. The item of RegionType.Point = 0 may not be passed so we do not check it.