### PR TITLE
Fix the the condition of disorder of returning messages

### DIFF
--- a/src/test/ANIMATOR_DATA_STREAM.test.ts
+++ b/src/test/ANIMATOR_DATA_STREAM.test.ts
@@ -109,8 +109,8 @@ describe("ANIMATOR_DATA_STREAM test: Testing data streaming with animator", () =
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.file);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.imageChannels[0]);
             await Connection.receive(CARTA.RasterTileData);
             await Connection.send(CARTA.SetCursor, assertItem.cursor);

--- a/src/test/ANIMATOR_NAVIGATION.test.ts
+++ b/src/test/ANIMATOR_NAVIGATION.test.ts
@@ -194,8 +194,8 @@ describe("ANIMATOR_NAVIGATION test: Testing using animator to see different fram
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             for (let i = 0; i < assertItem.fileOpens.length; i++) {
                 await Connection.send(CARTA.OpenFile, assertItem.fileOpens[i]);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels[i]);
                 await Connection.receive(CARTA.RasterTileData);
             }

--- a/src/test/ANIMATOR_PLAYBACK.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK.test.ts
@@ -134,8 +134,8 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpens);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         describe(`Play all images forwardly with looping`, () => {

--- a/src/test/CASA_REGION_EXPORT.test.ts
+++ b/src/test/CASA_REGION_EXPORT.test.ts
@@ -255,7 +255,8 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             for (let region of assertItem.setRegion) {
                 await Connection.send(CARTA.SetRegion, region);
                 await Connection.receive(CARTA.SetRegionAck);

--- a/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
@@ -67,7 +67,8 @@ describe("CASA_REGION_IMPORT_EXCEPTION test: Testing import/export of CASA regio
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -190,7 +190,8 @@ describe("CASA_REGION_IMPORT_EXPORT test: Testing import/export of CASA region f
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         describe(`Import "${assertItem.importRegion.file}"`, () => {

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -314,7 +314,8 @@ describe("CASA_REGION_IMPORT_INTERNAL test: Testing import of CASA region files 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {

--- a/src/test/CASA_REGION_INFO.test.ts
+++ b/src/test/CASA_REGION_INFO.test.ts
@@ -139,7 +139,8 @@ describe("CASA_REGION_INFO test: Testing CASA region list and info", () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         describe(`Go to "${regionSubdirectory}" and send REGION_LIST_REQUEST`, () => {

--- a/src/test/CHECK_RASTER_TILE_DATA.test.ts
+++ b/src/test/CHECK_RASTER_TILE_DATA.test.ts
@@ -205,10 +205,12 @@ describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers i
 
         describe(`Open image "${assertItem.fileOpen.file}"`, () => {
             let OpenFileAckTemp: CARTA.OpenFileAck;
+            let ack: any = [];
             test(`OPEN_FILE_ACK should arrive within ${openFileTimeout} ms.`, async () => {
                 await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-                OpenFileAckTemp = await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                ack.push(await Connection.receiveAny());
+                ack.push(await Connection.receiveAny()); // OpenFileAck | RegionHistogramData
+                OpenFileAckTemp = ack.find(r => r.constructor.name === "OpenFileAck") as CARTA.OpenFileAck;
             }, openFileTimeout);
 
             test(`OPEN_FILE_ACK.success = ${assertItem.fileOpenAck.success}`, () => {

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -2,7 +2,7 @@ import { CARTA } from "carta-protobuf";
 import config from "./config.json";
 
 export class Client {
-    IcdVersion: number = 10;
+    IcdVersion: number = 11;
     CartaType = new Map<number, any>([
         [ 0, CARTA.ErrorData],
         [ 1, CARTA.RegisterViewer],

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -231,7 +231,7 @@ export class Client {
             RegionStatsData: [],
             RegionHistogramData: [],
             SpectralProfileData: [],
-            Acknowledgement: [],
+            Responce: [],
         };
 
         return new Promise<AckStream>(resolve => {
@@ -272,7 +272,7 @@ export class Client {
                         ack.SpectralProfileData.push(_profileData);
                         break;
                     default:
-                        ack.Acknowledgement.push(this.CartaType.get(eventNumber).decode(eventData));
+                        ack.Responce.push(this.CartaType.get(eventNumber).decode(eventData));
                         break;
                 }
 
@@ -292,7 +292,7 @@ export interface AckStream {
     RegionStatsData: CARTA.RegionStatsData[];
     RegionHistogramData: CARTA.RegionHistogramData[];
     SpectralProfileData: CARTA.SpectralProfileData[];
-    Acknowledgement: any[],
+    Responce: any[],
 }
 interface ProcessedSpatialProfile extends CARTA.ISpatialProfile { values: Float32Array; }
 function processSpatialProfile(profile: CARTA.ISpatialProfile): ProcessedSpatialProfile {

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -247,7 +247,7 @@ export class Client {
                 if (eventIcdVersion !== this.IcdVersion && config.log.warning) {
                     console.warn(`Server event has ICD version ${eventIcdVersion}, which differs from frontend version ${this.IcdVersion}. Errors may occur`);
                 }
-                let _profileData;
+                let data;
                 switch (this.CartaType.get(eventNumber)) {
                     case CARTA.RasterTileData:
                         ack.RasterTileData.push(CARTA.RasterTileData.decode(eventData));
@@ -262,14 +262,14 @@ export class Client {
                         ack.RegionHistogramData.push(CARTA.RegionHistogramData.decode(eventData));
                         break;
                     case CARTA.SpatialProfileData:
-                        _profileData = CARTA.SpatialProfileData.decode(eventData);
-                        _profileData.profiles = _profileData.profiles.map(p => processSpatialProfile(p));
-                        ack.SpatialProfileData.push(_profileData);
+                        data = CARTA.SpatialProfileData.decode(eventData);
+                        data.profiles = data.profiles.map(p => processSpatialProfile(p));
+                        ack.SpatialProfileData.push(data);
                         break;
                     case CARTA.SpectralProfileData:
-                        _profileData = CARTA.SpectralProfileData.decode(eventData);
-                        _profileData.profiles = _profileData.profiles.map(p => processSpectralProfile(p));
-                        ack.SpectralProfileData.push(_profileData);
+                        data = CARTA.SpectralProfileData.decode(eventData);
+                        data.profiles = data.profiles.map(p => processSpectralProfile(p));
+                        ack.SpectralProfileData.push(data);
                         break;
                     default:
                         ack.Responce.push(this.CartaType.get(eventNumber).decode(eventData));

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -231,6 +231,7 @@ export class Client {
             RegionStatsData: [],
             RegionHistogramData: [],
             SpectralProfileData: [],
+            Acknowledgement: [],
         };
 
         return new Promise<AckStream>(resolve => {
@@ -271,6 +272,7 @@ export class Client {
                         ack.SpectralProfileData.push(_profileData);
                         break;
                     default:
+                        ack.Acknowledgement.push(this.CartaType.get(eventNumber).decode(eventData));
                         break;
                 }
 
@@ -290,6 +292,7 @@ export interface AckStream {
     RegionStatsData: CARTA.RegionStatsData[];
     RegionHistogramData: CARTA.RegionHistogramData[];
     SpectralProfileData: CARTA.SpectralProfileData[];
+    Acknowledgement: any[],
 }
 interface ProcessedSpatialProfile extends CARTA.ISpatialProfile { values: Float32Array; }
 function processSpatialProfile(profile: CARTA.ISpatialProfile): ProcessedSpatialProfile {

--- a/src/test/CURSOR_SPATIAL_PROFILE.test.ts
+++ b/src/test/CURSOR_SPATIAL_PROFILE.test.ts
@@ -240,8 +240,8 @@ describe("CURSOR_SPATIAL_PROFILE test: Testing if full resolution cursor spatial
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel);
             await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialRequirements);
             await Connection.receive(CARTA.RasterTileData);

--- a/src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts
+++ b/src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts
@@ -113,8 +113,8 @@ describe("CURSOR_SPATIAL_PROFILE_NaN test: Testing if full resolution cursor spa
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel);
             await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialRequirements);
             await Connection.receive(CARTA.RasterTileData);

--- a/src/test/CURSOR_SPECTRAL_PROFILE.test.ts
+++ b/src/test/CURSOR_SPECTRAL_PROFILE.test.ts
@@ -268,8 +268,8 @@ describe("CURSOR_SPATIAL_PROFILE test: Testing if full resolution cursor spatial
                 await Connection.receive(CARTA.RegisterViewerAck);
                 await Connection.send(CARTA.CloseFile, { fileId: -1 });
                 await Connection.send(CARTA.OpenFile, fileOpen);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannelGroup[index]);
                 await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirementsGroup[index]);
                 await Connection.receive(CARTA.RasterTileData);

--- a/src/test/OPEN_IMAGE_APPEND.test.ts
+++ b/src/test/OPEN_IMAGE_APPEND.test.ts
@@ -267,9 +267,14 @@ describe("OPEN_IMAGE_APPEND test: Testing the case of opening multiple images on
 
             describe(`open the file "${assertItem.fileOpenGroup[index].file}"`, () => {
                 let OpenFileAckTemp: CARTA.OpenFileAck;
-                test(`OPEN_FILE_ACK should arrive within ${openFileTimeout} ms`, async () => {
+                let RegionHistogramDataTemp: CARTA.RegionHistogramData;
+                let ack: any = [];
+                test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
                     await Connection.send(CARTA.OpenFile, assertItem.fileOpenGroup[index]);
-                    OpenFileAckTemp = await Connection.receive(CARTA.OpenFileAck);
+                    ack.push(await Connection.receiveAny());
+                    ack.push(await Connection.receiveAny()); // OpenFileAck | RegionHistogramData
+                    OpenFileAckTemp = ack.find(r => r.constructor.name === "OpenFileAck") as CARTA.OpenFileAck;
+                    RegionHistogramDataTemp = ack.find(r => r.constructor.name === "RegionHistogramData") as CARTA.RegionHistogramData;
                 }, openFileTimeout);
 
                 test(`OPEN_FILE_ACK.success = ${fileOpenAck.success}`, () => {
@@ -279,11 +284,6 @@ describe("OPEN_IMAGE_APPEND test: Testing the case of opening multiple images on
                 test(`OPEN_FILE_ACK.file_id = ${fileOpenAck.fileId}`, () => {
                     expect(OpenFileAckTemp.fileId).toEqual(fileOpenAck.fileId);
                 });
-
-                let RegionHistogramDataTemp: CARTA.RegionHistogramData;
-                test(`REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
-                    RegionHistogramDataTemp = await Connection.receive(CARTA.RegionHistogramData);
-                }, openFileTimeout);
 
                 test(`REGION_HISTOGRAM_DATA.file_id = ${assertItem.regionHistogramDataGroup[index].fileId}`, () => {
                     expect(RegionHistogramDataTemp.fileId).toEqual(assertItem.regionHistogramDataGroup[index].fileId);

--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -88,8 +88,8 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
                 await Connection.receive(CARTA.RegisterViewerAck);
                 await Connection.send(CARTA.CloseFile, { fileId: -1 });
                 await Connection.send(CARTA.OpenFile, fileOpen);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             }, connectTimeout);

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -88,8 +88,8 @@ describe("PER_CUBE_HISTOGRAM_CANCELLATION tests: Testing the cancellation capabi
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
             await Connection.receive(CARTA.RasterTileData);
         });

--- a/src/test/REGION_DATA_STREAM.test.ts
+++ b/src/test/REGION_DATA_STREAM.test.ts
@@ -133,8 +133,8 @@ describe("REGION_DATA_STREAM test: Testing data streaming with regions", () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
             await Connection.receive(CARTA.RasterTileData);
             await Connection.send(CARTA.SetRegion, assertItem.setRegion[0]);

--- a/src/test/REGION_HISTOGRAM.test.ts
+++ b/src/test/REGION_HISTOGRAM.test.ts
@@ -151,8 +151,8 @@ describe("REGION_HISTOGRAM test: Testing histogram with rectangle regions", () =
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/REGION_OPERATIONS.test.ts
+++ b/src/test/REGION_OPERATIONS.test.ts
@@ -168,8 +168,8 @@ describe("REGION_OPERATIONS test: Testing region creation and modification", () 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
             await Connection.receive(CARTA.RasterTileData);
         });

--- a/src/test/REGION_SPECTRAL_PROFILE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE.test.ts
@@ -449,8 +449,8 @@ describe("REGION_SPECTRAL_PROFILE test: Testing spectral profiler with regions",
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/REGION_SPECTRAL_PROFILE_STOKES.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_STOKES.test.ts
@@ -198,8 +198,8 @@ describe("REGION_SPECTRAL_PROFILE_STOKES test: Testing spectral profiler with re
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels[0]);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/REGION_STATISTICS_ELLIPSE.test.ts
+++ b/src/test/REGION_STATISTICS_ELLIPSE.test.ts
@@ -194,8 +194,8 @@ describe("REGION_STATISTICS_ELLIPSE test: Testing statistics with ellipse region
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/REGION_STATISTICS_POLYGON.test.ts
+++ b/src/test/REGION_STATISTICS_POLYGON.test.ts
@@ -312,8 +312,8 @@ describe("REGION_STATISTICS_POLYGON test: Testing statistics with polygon region
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/REGION_STATISTICS_RECTANGLE.test.ts
+++ b/src/test/REGION_STATISTICS_RECTANGLE.test.ts
@@ -268,8 +268,8 @@ describe("REGION_STATISTICS_RECTANGLE test: Testing statistics with rectangle re
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1, });
                 await Connection.send(CARTA.OpenFile, openFile);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannels);
                 await Connection.receive(CARTA.RasterTileData);
             });

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -118,7 +118,7 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
             }, resumeTimeout);
 
             test(`RESUME_SESSION_ACK.success = ${assertItem.resumeSessionAck.success}`, () => {
-                let ResumeSessionAckTemp = Ack.Acknowledgement[0] as CARTA.ResumeSessionAck;
+                let ResumeSessionAckTemp = Ack.Responce[0] as CARTA.ResumeSessionAck;
                 expect(ResumeSessionAckTemp.success).toBe(assertItem.resumeSessionAck.success);
                 if (ResumeSessionAckTemp.message) {
                     console.warn(`RESUME_SESSION_ACK error message: 

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -112,7 +112,7 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
 
         describe(`RESUME_SESSION`, () => {
             let Ack: AckStream;
-            test(`OPEN_FILE_ACK & SET_REGION_ACK & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
+            test(`Some REGION_HISTOGRAM_DATA & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
                 await Connection.send(CARTA.ResumeSession, assertItem.resumeSession);
                 Ack = await Connection.stream(3) as AckStream;
             }, resumeTimeout);

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -115,35 +115,20 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
         });
 
         describe(`RESUME_SESSION`, () => {
-            let OpenFileAckTemp: CARTA.OpenFileAck[] = new Array(assertItem.resumeSession.images.length);
-            let SetRegionAckTemp: CARTA.SetRegionAck[] = new Array(assertItem.resumeSession.images.length);
-            let ResumeSessionAckTemp: CARTA.ResumeSessionAck;
+            let Ack: Utility.AckStream;
             test(`OPEN_FILE_ACK & SET_REGION_ACK & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
                 await Utility.setEventAsync(Connection, CARTA.ResumeSession, assertItem.resumeSession);
-                for (let i = 0; i< assertItem.resumeSession.images.length; i++) {
-                    OpenFileAckTemp[i] = await Utility.getEventAsync(Connection, CARTA.OpenFileAck) as CARTA.OpenFileAck;
-                    SetRegionAckTemp[i] = await Utility.getEventAsync(Connection, CARTA.SetRegionAck) as CARTA.SetRegionAck;
-                }
-                ResumeSessionAckTemp = await Utility.getEventAsync(Connection, CARTA.ResumeSessionAck) as CARTA.ResumeSessionAck;
+                Ack = await Utility.getStreamAsync(Connection, 3) as Utility.AckStream;
             }, resumeTimeout);
 
-            for (let index = 0; index< assertItem.resumeSession.images.length; index++) {
-                test(`OPEN_FILE_ACK.success = ${assertItem.openFileAck[index].success}`, () => {
-                    expect(OpenFileAckTemp[index].success).toBe(assertItem.openFileAck[index].success);
-                });
-                test(`SET_REGION_ACK.success = ${assertItem.setRegionAck[index].success}`, () => {
-                    expect(SetRegionAckTemp[index].success).toBe(assertItem.setRegionAck[index].success);
-                });
-            }
-
             test(`RESUME_SESSION_ACK.success = ${assertItem.resumeSessionAck.success}`, () => {
-                expect(ResumeSessionAckTemp.success).toBe(assertItem.resumeSessionAck.success);
+                expect(Ack.ResumeSessionAck[0].success).toBe(assertItem.resumeSessionAck.success);
+                if (Ack.ResumeSessionAck[0].message) {
+                    console.warn(`RESUME_SESSION_ACK error message: 
+                        ${Ack.ResumeSessionAck[0].message}`);
+                }
             });
 
-            if (ResumeSessionAckTemp.message) {
-                console.warn(`RESUME_SESSION_ACK error message: 
-                    ${ResumeSessionAckTemp.message}`);
-            }
 
         });
 

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -1,5 +1,5 @@
-import {CARTA} from "carta-protobuf";
-import * as Utility from "./testUtilityFunction";
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
@@ -7,7 +7,7 @@ let connectTimeout = config.timeout.connection;
 let resumeTimeout = config.timeout.resume;
 
 interface AssertItem {
-    registerViewer: CARTA.IRegisterViewer;
+    register: CARTA.IRegisterViewer;
     precisionDigits: number;
     resumeSession?: CARTA.IResumeSession;
     resumeSessionAck?: CARTA.IResumeSessionAck;
@@ -15,61 +15,61 @@ interface AssertItem {
     setRegionAck?: CARTA.ISetRegionAck[];
 }
 let assertItem: AssertItem = {
-    registerViewer: {
-        sessionId: 0, 
+    register: {
+        sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
     },
     precisionDigits: 4,
-    resumeSession: 
+    resumeSession:
     {
-        images: 
-        [
-            {
-                directory: testSubdirectory, 
-                file: "M17_SWex.fits",
-                fileId: 0,
-                hdu: "",
-                renderMode: CARTA.RenderMode.RASTER,
-                tileSize: 256,
-                channel: 0,
-                stokes: 0,
-                regions:
-                [
-                    {
-                        regionId: 1,
-                        regionInfo: {                            
-                            regionName: "",
-                            regionType: CARTA.RegionType.RECTANGLE,
-                            controlPoints: [{x: 276.066, y: 377.278}, {x: 84.8485, y: 68.6869}],
-                            rotation: 0,
-                        },
-                    },
-                ],
-            },
-            {
-                directory: testSubdirectory, 
-                file: "M17_SWex.image",
-                fileId: 1,
-                hdu: "",
-                renderMode: CARTA.RenderMode.RASTER,
-                tileSize: 256,
-                channel: 0,
-                stokes: 0,
-                regions:
-                [
-                    {
-                        regionId: 2,
-                        regionInfo: {                            
-                            regionName: "",
-                            regionType: CARTA.RegionType.RECTANGLE,
-                            controlPoints: [{x: 276.066, y: 385.359}, {x: 82.8283, y: 64.6465}],
-                            rotation: 0,
-                        },
-                    },
-                ],
-            },
-        ]
+        images:
+            [
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.fits",
+                    fileId: 0,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    tileSize: 256,
+                    channel: 0,
+                    stokes: 0,
+                    regions:
+                        [
+                            {
+                                regionId: 1,
+                                regionInfo: {
+                                    regionName: "",
+                                    regionType: CARTA.RegionType.RECTANGLE,
+                                    controlPoints: [{ x: 276.066, y: 377.278 }, { x: 84.8485, y: 68.6869 }],
+                                    rotation: 0,
+                                },
+                            },
+                        ],
+                },
+                {
+                    directory: testSubdirectory,
+                    file: "M17_SWex.image",
+                    fileId: 1,
+                    hdu: "",
+                    renderMode: CARTA.RenderMode.RASTER,
+                    tileSize: 256,
+                    channel: 0,
+                    stokes: 0,
+                    regions:
+                        [
+                            {
+                                regionId: 2,
+                                regionInfo: {
+                                    regionName: "",
+                                    regionType: CARTA.RegionType.RECTANGLE,
+                                    controlPoints: [{ x: 276.066, y: 385.359 }, { x: 82.8283, y: 64.6465 }],
+                                    rotation: 0,
+                                },
+                            },
+                        ],
+                },
+            ]
     },
     resumeSessionAck:
     {
@@ -77,62 +77,58 @@ let assertItem: AssertItem = {
         message: "",
     },
     openFileAck:
-    [
-        {
-            success: true,
-        },
-        {
-            success: true,
-        },
-    ],
+        [
+            {
+                success: true,
+            },
+            {
+                success: true,
+            },
+        ],
     setRegionAck:
-    [
-        {
-            success: true,
-        },
-        {
-            success: true,
-        },
-    ],
+        [
+            {
+                success: true,
+            },
+            {
+                success: true,
+            },
+        ],
 }
 
-describe("RESUME SESSION test: Test to resume images and regions", () => {   
-    let Connection: WebSocket;
-    beforeAll( done => {
-        Connection = new WebSocket(testServerUrl);
-        Connection.binaryType = "arraybuffer";
-        Connection.onopen = OnOpen;
-        async function OnOpen (this: WebSocket, ev: Event) {
-            await Utility.setEventAsync(this, CARTA.RegisterViewer, assertItem.registerViewer);
-            await Utility.getEventAsync(this, CARTA.RegisterViewerAck);
-            done();
-        }
+describe("RESUME SESSION test: Test to resume images and regions", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.send(CARTA.RegisterViewer, assertItem.register);
+        await Connection.receive(CARTA.RegisterViewerAck);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder`, () => {
 
-        beforeAll( async () => {
+        beforeAll(async () => {
         });
 
         describe(`RESUME_SESSION`, () => {
-            let Ack: Utility.AckStream;
+            let Ack: AckStream;
             test(`OPEN_FILE_ACK & SET_REGION_ACK & RESUME_SESSION_ACK should arrive within ${resumeTimeout} ms`, async () => {
-                await Utility.setEventAsync(Connection, CARTA.ResumeSession, assertItem.resumeSession);
-                Ack = await Utility.getStreamAsync(Connection, 3) as Utility.AckStream;
+                await Connection.send(CARTA.ResumeSession, assertItem.resumeSession);
+                Ack = await Connection.stream(3) as AckStream;
             }, resumeTimeout);
 
             test(`RESUME_SESSION_ACK.success = ${assertItem.resumeSessionAck.success}`, () => {
-                expect(Ack.ResumeSessionAck[0].success).toBe(assertItem.resumeSessionAck.success);
-                if (Ack.ResumeSessionAck[0].message) {
+                let ResumeSessionAckTemp = Ack.Acknowledgement[0];
+                expect(ResumeSessionAckTemp.success).toBe(assertItem.resumeSessionAck.success);
+                if (ResumeSessionAckTemp.message) {
                     console.warn(`RESUME_SESSION_ACK error message: 
-                        ${Ack.ResumeSessionAck[0].message}`);
+                        ${ResumeSessionAckTemp.message}`);
                 }
             });
-
 
         });
 
     });
 
-    afterAll( () => Connection.close());
+    afterAll(() => Connection.close());
 });

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -118,7 +118,7 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
             }, resumeTimeout);
 
             test(`RESUME_SESSION_ACK.success = ${assertItem.resumeSessionAck.success}`, () => {
-                let ResumeSessionAckTemp = Ack.Acknowledgement[0];
+                let ResumeSessionAckTemp = Ack.Acknowledgement[0] as CARTA.ResumeSessionAck;
                 expect(ResumeSessionAckTemp.success).toBe(assertItem.resumeSessionAck.success);
                 if (ResumeSessionAckTemp.message) {
                     console.warn(`RESUME_SESSION_ACK error message: 

--- a/src/test/RESUME_SESSION.test.ts
+++ b/src/test/RESUME_SESSION.test.ts
@@ -102,7 +102,8 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
         await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        let ack = await Connection.receiveAny();
+        expect(ack.constructor.name).toEqual(CARTA.RegisterViewerAck.name);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder`, () => {
@@ -118,7 +119,7 @@ describe("RESUME SESSION test: Test to resume images and regions", () => {
             }, resumeTimeout);
 
             test(`RESUME_SESSION_ACK.success = ${assertItem.resumeSessionAck.success}`, () => {
-                let ResumeSessionAckTemp = Ack.Responce[0] as CARTA.ResumeSessionAck;
+                let ResumeSessionAckTemp = Ack.Responce.filter(r => r.constructor.name === "ResumeSessionAck")[0] as CARTA.ResumeSessionAck;
                 expect(ResumeSessionAckTemp.success).toBe(assertItem.resumeSessionAck.success);
                 if (ResumeSessionAckTemp.message) {
                     console.warn(`RESUME_SESSION_ACK error message: 

--- a/src/test/TILE_DATA_ORDER.test.ts
+++ b/src/test/TILE_DATA_ORDER.test.ts
@@ -162,8 +162,8 @@ describe(`TILE_DATA_ORDER test: Testing the order of returning tiles`, () => {
             beforeAll(async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: -1 });
                 await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-                await Connection.receive(CARTA.OpenFileAck);
-                await Connection.receive(CARTA.RegionHistogramData);
+                await Connection.receiveAny();
+                await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
             });
 
             describe(`SET_IMAGE_CHANNELS on the file "${assertItem.fileOpen.file}" with ${setImageChannel.requiredTiles.tiles.length} tiles`, () => {

--- a/src/test/TILE_DATA_REQUEST.test.ts
+++ b/src/test/TILE_DATA_REQUEST.test.ts
@@ -120,8 +120,8 @@ describe(`TILE_DATA_REQUEST test: Testing tile requesting messages "SET_IMAGE_CH
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
             await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receive(CARTA.OpenFileAck);
-            await Connection.receive(CARTA.RegionHistogramData);
+            await Connection.receiveAny();
+            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
         });
 
         describe(`SET_IMAGE_CHANNELS on the file "${assertItem.fileOpen.file}"`, () => {


### PR DESCRIPTION
The use case in RESUME_SESSION showed up this trouble. After frontend sending the CARTA.OpenFile, the backend should return two messages, OpenFileAck and RegionHistorgramData. The issue is these two messages does not return orderly, so we need to enhance the method of testing for a similar kind of situation, ie. #51.
Fixed all use cases on the tests about CARTA.OpenFile action.