### PR TITLE
change expect(REGISTER_VIEWER_ACK) from .toBe() to .toBeDefined()

### DIFF
--- a/src/test/ACCESS_CARTA_DEFAULT.test.ts
+++ b/src/test/ACCESS_CARTA_DEFAULT.test.ts
@@ -47,8 +47,11 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
             expect(RegisterViewerAckTemp.sessionType).toBe(CARTA.SessionType.NEW);
         });
 
-        test("REGISTER_VIEWER_ACK.message is empty", () => {
-            expect(RegisterViewerAckTemp.message).toBe("");
+        test("REGISTER_VIEWER_ACK.message is be defined ", () => {
+            expect(RegisterViewerAckTemp.message).toBeDefined();
+            if (RegisterViewerAckTemp.message !== ""){
+                console.warn(`"REGISTER_VIEWER_ACK.message" returns: "${RegisterViewerAckTemp.message}" @${new Date()}`)
+            };
         });
 
         test("REGISTER_VIEWER_ACK.server_feature_flags = 0", () => {


### PR DESCRIPTION
#77 
Change the expected result from toBe() to toBeDefined() and also print the REGISTER_VIEWER_ACK return.