### PR TITLE
Enhance basic testing for websocket

### DIFF
--- a/src/test/ACCESS_WEBSOCKET.test.ts
+++ b/src/test/ACCESS_WEBSOCKET.test.ts
@@ -10,6 +10,9 @@ describe("ACCESS_WEBSOCKET tests: Testing connections to the websocket server", 
 
         // While open a Websocket
         Connection.onopen = () => {
+            if (config.log.event) {
+                console.log(testRemoteWebsocketSite + "  opened");
+            }
             Connection.close();
             done();     // Return to this test
         };
@@ -21,17 +24,24 @@ describe("ACCESS_WEBSOCKET tests: Testing connections to the websocket server", 
         expect(Connection.readyState).toBe(WebSocket.CONNECTING);
         
         Connection.onopen = OnOpen;
-        Connection.onclose = OnClose;
 
         function OnOpen (this: WebSocket, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
+            if (config.log.event) {
+                console.log(testServerUrl + "  opened");
+            }
             
             this.close();
             expect(this.readyState).toBe(WebSocket.CLOSING);
-        }
-        function OnClose (this: WebSocket, ev: CloseEvent) {
-            expect(this.readyState).toBe(WebSocket.CLOSED);
-            done();
+
+            Connection.onclose = OnClose;
+            function OnClose (this: WebSocket, ev: CloseEvent) {
+                expect(this.readyState).toBe(WebSocket.CLOSED);
+                if (config.log.event) {
+                    console.log(testServerUrl + "  closed");
+                }
+                done();
+            }
         }
 
     }, connectTimeout);


### PR DESCRIPTION
In case of #87, while the connection is interrupted as soon as the websocket server is opening, the previous test will be passed. The new test can detect if the connection is opened as correct as we expect. This PR doesn't fix the issue #87 but give a warning correctly about the testing should failed in this situation.