### PR TITLE
change RegisterViewerAckTemp.serverFeatureFlags = 0->8 and update ICD version

### DIFF
--- a/src/test/ACCESS_CARTA_DEFAULT.test.ts
+++ b/src/test/ACCESS_CARTA_DEFAULT.test.ts
@@ -54,8 +54,8 @@ describe("ACCESS_CARTA_DEFAULT tests: Testing connections to the backend", () =>
             };
         });
 
-        test("REGISTER_VIEWER_ACK.server_feature_flags = 0", () => {
-            expect(RegisterViewerAckTemp.serverFeatureFlags).toEqual(0);
+        test("REGISTER_VIEWER_ACK.server_feature_flags = 8", () => {
+            expect(RegisterViewerAckTemp.serverFeatureFlags).toEqual(8);
         });
     });
 });

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -2,7 +2,7 @@ import { CARTA } from "carta-protobuf";
 import config from "./config.json";
 
 export class Client {
-    IcdVersion: number = 11;
+    IcdVersion: number = 12;
     CartaType = new Map<number, any>([
         [ 0, CARTA.ErrorData],
         [ 1, CARTA.RegisterViewer],


### PR DESCRIPTION
#91 
checking with acdc server, the `ACCESS_CARTA_DEFAULT.test.ts` only passed with changing 

> RegisterViewerAckTemp.serverFeatureFlags = 8

also update the ICD version from 11 to 12, not sure CLIENT.ts should be updated further.....

Very very very sorry about I open the wrong PR.... because I did not manage my branch very well, so I PR this one as an update. It is more clear that I only have 1 commit with 2 files: `ACCESS_CARTA_DEFAULT.test.ts` & `CLIENT.ts`