### PR TITLE
Remove tileSize from fileOpen & fileOpenAck

### DIFF
--- a/src/test/CHECK_RASTER_TILE_DATA.test.ts
+++ b/src/test/CHECK_RASTER_TILE_DATA.test.ts
@@ -42,12 +42,10 @@ let assertItem: AssertItem = {
         hdu: "",
         fileId: 0,
         renderMode: CARTA.RenderMode.RASTER,
-        tileSize: 256,
     },
     fileOpenAck: {
         success: true,
         fileFeatureFlags: 0,
-        tileSize: 256,
     },
     regionHistogram: {
         fileId: 0,
@@ -215,10 +213,6 @@ describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers i
             test(`OPEN_FILE_ACK.success = ${assertItem.fileOpenAck.success}`, () => {
                 OpenFileAckTemp = ack.find(r => r.constructor.name === CARTA.OpenFileAck.name) as CARTA.OpenFileAck;
                 expect(OpenFileAckTemp.success).toBe(assertItem.fileOpenAck.success);
-            });
-
-            test(`OPEN_FILE_ACK.file_info.tile_size = ${assertItem.fileOpenAck.tileSize}`, () => {
-                expect(OpenFileAckTemp.tileSize).toEqual(assertItem.fileOpenAck.tileSize);
             });
 
         });

--- a/src/test/CHECK_RASTER_TILE_DATA.test.ts
+++ b/src/test/CHECK_RASTER_TILE_DATA.test.ts
@@ -42,10 +42,12 @@ let assertItem: AssertItem = {
         hdu: "",
         fileId: 0,
         renderMode: CARTA.RenderMode.RASTER,
+        // tileSize: 256,
     },
     fileOpenAck: {
         success: true,
         fileFeatureFlags: 0,
+        // tileSize: 256,
     },
     regionHistogram: {
         fileId: 0,
@@ -214,6 +216,10 @@ describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers i
                 OpenFileAckTemp = ack.find(r => r.constructor.name === CARTA.OpenFileAck.name) as CARTA.OpenFileAck;
                 expect(OpenFileAckTemp.success).toBe(assertItem.fileOpenAck.success);
             });
+
+            // test(`OPEN_FILE_ACK.file_info.tile_size = ${assertItem.fileOpenAck.tileSize}`, () => {
+            //     expect(OpenFileAckTemp.tileSize).toEqual(assertItem.fileOpenAck.tileSize);
+            // });
 
         });
 


### PR DESCRIPTION
Fixed minor error in "CHECK_RASTER_TILE_DATA.test.ts" (remove properties and related test)
Because the property of tileSize has been remove from carta-protopuf.