### PR TITLE
Mylin/#90 revice animator

### DIFF
--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -124,6 +124,14 @@ let assertItem: AssertItem = {
                 fileId: 0,
                 animationId: 4,
             },
+            {
+                fileId: 0,
+                animationId: 5,
+            },
+            {
+                fileId: 0,
+                animationId: 6,
+            },
         ],
     setImageChannel:
         [
@@ -161,36 +169,36 @@ let assertItem: AssertItem = {
                 },
             },
         ],
-    // reverseAnimation:
-    //     [
-    //         {
-    //             fileId: 0,
-    //             startFrame: { channel: 20, stokes: 0 },
-    //             firstFrame: { channel: 10, stokes: 0 },
-    //             lastFrame: { channel: 20, stokes: 0 },
-    //             deltaFrame: { channel: 1, stokes: 0 },
-    //             requiredTiles: {
-    //                 fileId: 0,
-    //                 tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
-    //                 compressionType: CARTA.CompressionType.ZFP,
-    //                 compressionQuality: 9,
-    //             },
-    //             reverse: true,
-    //         },
-    //         // {
-    //         //     fileId: 0,
-    //         //     startFrame: { channel: 20, stokes: 0 },
-    //         //     firstFrame: { channel: 10, stokes: 0 },
-    //         //     lastFrame: { channel: 20, stokes: 0 },
-    //         //     deltaFrame: { channel: -1, stokes: 0 },
-    //         //     requiredTiles: {
-    //         //         fileId: 0,
-    //         //         tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
-    //         //         compressionType: CARTA.CompressionType.ZFP,
-    //         //         compressionQuality: 9,
-    //         //     },
-    //         // },
-    //     ],
+    reverseAnimation:
+        [
+            {
+                fileId: 0,
+                startFrame: { channel: 20, stokes: 0 },
+                firstFrame: { channel: 10, stokes: 0 },
+                lastFrame: { channel: 20, stokes: 0 },
+                deltaFrame: { channel: 1, stokes: 0 },
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 9,
+                },
+                reverse: true,
+            },
+            {
+                fileId: 0,
+                startFrame: { channel: 20, stokes: 0 },
+                firstFrame: { channel: 10, stokes: 0 },
+                lastFrame: { channel: 20, stokes: 0 },
+                deltaFrame: { channel: -1, stokes: 0 },
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 9,
+                },
+            },
+        ],
     // blinkAnimation:
     // {
     //     fileId: 0,
@@ -227,7 +235,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
         }, connectTimeout);
 
-        describe(`(Step 1) Initialization: the open image"`, () => {
+        describe(`(Step 1) Initialization: the open image`, () => {
             test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
                 await Connection.send(CARTA.CloseFile, { fileId: 0 });
                 await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
@@ -248,7 +256,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
 
         });
 
-        describe(`(Step 2):Play all images forwardly`, () => {
+        describe(`(Step 2):Play some channels forwardly`, () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one and the last channel is correct:`, async () => {
@@ -283,13 +291,13 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 let lastRasterImageData = await Connection.stream(14) as AckStream;
                 // console.log(lastRasterImageData); // RasterTileData * 12 + RasterTileSync *2 (start & end)
                 // console.log(AnimateStreamData); // RasterTileData * 12 + SpatialProfileData * 1 + RegionHistogramData * 1 + RasterTileSync *2 (start & end)
-                console.log(sequence); // show looping sequence
+                // console.log(sequence); // show looping sequence
                 expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation[0].endFrame.channel);
 
             }, playImageTimeout)
 
             test(`Received image channels should be in sequence`, async () => {
-                console.log(`Sequent channel index: ${sequence}`);
+                console.warn(`(Step 2) Sequent channel index: ${sequence}`);
                 AnimateStreamData.map((imageData, index) => {
                     let j = (index + assertItem.startAnimation[0].startFrame.channel + assertItem.startAnimation[0].deltaFrame.channel) - 1.;
                     // let i = 3 * Math.abs(assertItem.stopAnimation[0].endFrame.channel - assertItem.startAnimation[0].firstFrame.channel) + 5;
@@ -299,7 +307,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             });
         });
 
-        describe(`(Step 3) Play all images backwardly with looping`, () => {
+        describe(`(Step 3) Play some channels backwardly with looping`, () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
@@ -338,7 +346,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             }, playImageTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
-                console.log(`Sequent channel index: ${sequence}`);
+                console.warn(`(Step 3) Sequent channel index: ${sequence}`);
                 let i = 2 * Math.abs(assertItem.startAnimation[1].lastFrame.channel - assertItem.startAnimation[1].firstFrame.channel) + 1;
                 AnimateStreamData.map((imageData, index) => {
                     let j = i-- % Math.abs(1 + assertItem.startAnimation[1].lastFrame.channel - assertItem.startAnimation[1].firstFrame.channel) + assertItem.startAnimation[1].firstFrame.channel;
@@ -348,7 +356,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
 
         });
 
-        describe(`(Step 4 )Play some images until stop`, () => {
+        describe(`(Step 4 )Play some channels until stop`, () => {
             let AnimateStreamData: AckStream[] = [];
             let lastRasterImageData: AckStream;
             test(`Image should return one after one`, async () => {
@@ -380,15 +388,15 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[2]);
 
                 lastRasterImageData = await Connection.stream(16) as AckStream;
-                console.log(lastRasterImageData);
+                console.warn('(Step 4) Last Raster Tile channel:', lastRasterImageData.RasterTileData[0].channel);
                 // console.log(AnimateStreamData);
 
             }, playImageTimeout);
 
-            test(`Last image on channel${JSON.stringify(assertItem.stopAnimation[2].endFrame)} should receive after stop`, async () => {
+            test(`Last image on channel should receive after stop and should be between ${JSON.stringify(assertItem.stopAnimation[2].endFrame.channel)} and ${JSON.stringify(assertItem.stopAnimation[2].endFrame.channel + 2.)}`, async () => {
                 // console.log(lastRasterImageData.RasterTileData[0].channel);
                 expect(lastRasterImageData.RasterTileData[0].channel).toBeGreaterThanOrEqual(assertItem.stopAnimation[2].endFrame.channel);
-                expect(lastRasterImageData.RasterTileData[0].channel).toBeLessThan(assertItem.stopAnimation[2].endFrame.channel + 2.);
+                expect(lastRasterImageData.RasterTileData[0].channel).toBeLessThan(assertItem.stopAnimation[2].endFrame.channel + 3.);
             });
         });
 
@@ -427,50 +435,49 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             }, playImageTimeout);
 
             test(`Received image channels should be in sequence and then reverse:`, async () => {
-                console.log(`Channel index in roundtrip: ${sequence}`);
+                console.warn(`(Step 5) Channel index in roundtrip: ${sequence}`);
                 let previous: number = assertItem.startAnimation[0].lastFrame.channel;
                 // console.log(previous);
                 expect(Math.abs(sequence[sequence.length - 1] - previous)).toEqual(0);
             });
         });
 
-        // assertItem.reverseAnimation.map((animation, index) => {
-        //     describe(`(Step 6) Play all images backwardly using method${index + 1}`, () => {
-        //         let AnimateStreamData: AckStream[] = [];
-        //         let sequence: number[] = [];
-        //         test(`Image should return one after one`, async () => {
-        //             await Connection.send(CARTA.StartAnimation, animation);
-        //             await Connection.receive(CARTA.StartAnimationAck);
-        //             for (let i = 0; i < Math.abs(animation.lastFrame.channel - animation.firstFrame.channel); i++) {
-        //                 AnimateStreamData.push(await Connection.stream(16) as AckStream);
-        //                 await Connection.send(CARTA.AnimationFlowControl,
-        //                     {
-        //                         ...assertItem.animationFlowControl,
-        //                         receivedFrame: {
-        //                             channel: AnimateStreamData[i].RasterTileData[0].channel,
-        //                             stokes: 0
-        //                         },
-        //                         timestamp: Long.fromNumber(Date.now()),
-        //                         animationid: index + 5,
-        //                     }
-        //                 );
-        //                 sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
-        //             }
-        //             await Connection.send(CARTA.StopAnimation, CARTA.StopAnimation);
-        //             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[1])
-        //             let lastRasterImageData = await Connection.stream(14) as AckStream;
-        //             console.log(AnimateStreamData[0].RasterTileData);
-        //             console.log(sequence);
-        //         }, playImageTimeout);
+        assertItem.reverseAnimation.map((animation, index) => {
+            describe(`(Step 6) Play all images backwardly using method${index + 1}`, () => {
+                let AnimateStreamData: AckStream[] = [];
+                let sequence: number[] = [];
+                test(`Image should return one after one`, async () => {
+                    await Connection.send(CARTA.StartAnimation, animation);
+                    await Connection.receive(CARTA.StartAnimationAck);
+                    for (let i = 0; i < Math.abs(animation.lastFrame.channel - animation.firstFrame.channel); i++) {
+                        AnimateStreamData.push(await Connection.stream(16) as AckStream);
+                        await Connection.send(CARTA.AnimationFlowControl,
+                            {
+                                ...assertItem.animationFlowControl[4 + index],
+                                receivedFrame: {
+                                    channel: AnimateStreamData[i].RasterTileData[0].channel,
+                                    stokes: 0
+                                },
+                                timestamp: Long.fromNumber(Date.now()),
+                            }
+                        );
+                        sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
+                    }
+                    await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[2]);
+                    await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[2])
+                    let lastRasterImageData = await Connection.stream(14) as AckStream;
+                    // console.log(lastRasterImageData);
+                    // console.log(sequence);
+                }, playImageTimeout);
 
-        //         test(`Received image channels should be in sequence`, async () => {
-        //             console.log(`Backward channel index: ${sequence}`);
-        //             AnimateStreamData.map((imageData, index) => {
-        //                 expect(sequence[index]).toEqual(animation.startFrame.channel - index);
-        //             });
-        //         });
-        //     });
-        // });
+                test(`Received image channels should be in sequence`, async () => {
+                    console.warn(`(Step 6) Backward channel index with method${index + 1}: ${sequence}`);
+                    AnimateStreamData.map((imageData, index) => {
+                        expect(sequence[index]).toEqual(animation.startFrame.channel - index);
+                    });
+                });
+            });
+        });
     });
 
     test(`close file`, async () => {

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -10,6 +10,8 @@ let testSubdirectory: string = config.path.QA;
 let connectTimeout: number = config.timeout.connection;
 let openFileTimeout: number = config.timeout.openFile;
 let playImageTimeout: number = 10000;//config.timeout.playImages;
+let sleepTimeout: number = config.timeout.sleep
+let playAnimatorTimeout = config.timeout.playAnimator
 
 interface AssertItem {
     register: CARTA.IRegisterViewer;
@@ -248,7 +250,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
     });
 
     function sleep(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise(resolve => setTimeout(resolve, ms)).then(() => { console.log('sleep!') });
     }
 
     describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
@@ -315,7 +317,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 // console.log(sequence); // show looping sequence
                 expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation[0].endFrame.channel);
 
-            }, playImageTimeout)
+            }, playAnimatorTimeout)
 
             test(`Received image channels should be in sequence`, async () => {
                 console.warn(`(Step 2) Sequent channel index: ${sequence}`);
@@ -332,8 +334,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
-                await sleep(3000);
-                console.log('sleep!')
+                await sleep(sleepTimeout);
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[1],
                     looping: true,
@@ -366,7 +367,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 // console.log(sequence);
 
                 expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation[1].endFrame.channel);
-            }, playImageTimeout);
+            }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
                 console.warn(`(Step 3) Sequent channel index: ${sequence}`);
@@ -384,8 +385,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let lastRasterImageData: AckStream;
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
-                await sleep(3000);
-                console.log('sleep!')
+                await sleep(sleepTimeout);
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[2],
                     looping: true,
@@ -419,7 +419,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 // console.log(AnimateStreamData);
                 // console.log(lastRasterImageData)
 
-            }, playImageTimeout);
+            }, playAnimatorTimeout);
 
             test(`Last channel should be received after stop and should be ${JSON.stringify(assertItem.stopAnimation[2].endFrame.channel)}`, async () => {
                 console.warn(`(Step 4) Sequent channel index: ${sequence}`);
@@ -432,8 +432,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
-                await sleep(3000);
-                console.log('sleep!')
+                await sleep(sleepTimeout);
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[0],
                     reverse: true,
@@ -462,7 +461,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 // console.log(lastRasterImageData)
                 // console.log(sequence);
 
-            }, playImageTimeout);
+            }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence and then reverse:`, async () => {
                 console.warn(`(Step 5) Channel index in roundtrip: ${sequence}`);
@@ -477,8 +476,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 let AnimateStreamData: AckStream[] = [];
                 let sequence: number[] = [];
                 test(`Image should return one after one`, async () => {
-                    await sleep(3000);
-                    console.log('sleep!')
+                    await sleep(sleepTimeout);
                     await Connection.send(CARTA.StartAnimation, animation);
                     await Connection.receive(CARTA.StartAnimationAck);
                     for (let i = 0; i < Math.abs(animation.lastFrame.channel - animation.firstFrame.channel); i++) {
@@ -500,7 +498,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                     let lastRasterImageData = await Connection.stream(16) as AckStream;
                     // console.log(lastRasterImageData);
                     // console.log(sequence);
-                }, playImageTimeout);
+                }, playAnimatorTimeout);
 
                 test(`Received image channels should be in sequence`, async () => {
                     console.warn(`(Step 6) Backward channel index with method${index + 1}: ${sequence}`);
@@ -515,8 +513,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
-                await sleep(3000);
-                console.log('sleep!')
+                await sleep(sleepTimeout);
                 await Connection.send(CARTA.StartAnimation, assertItem.blinkAnimation);
                 await Connection.receive(CARTA.StartAnimationAck);
                 for (let i = 0; i < 11; i++) {
@@ -539,7 +536,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 // sequence.push(lastRasterImageData.channel);
                 // console.log(lastRasterImageData);
                 // console.log(sequence);
-            }, playImageTimeout);
+            }, playAnimatorTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
                 console.warn(`(Step 7) Blink channel index: ${sequence}`);

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -19,9 +19,11 @@ interface AssertItem {
     setCursor: CARTA.ISetCursor;
     setSpatialReq: CARTA.ISetSpatialRequirements;
     startAnimation: CARTA.IStartAnimation[];
-    stopAnimation: CARTA.IStopAnimation;
-    animationFlowControl: CARTA.IAnimationFlowControl;
+    stopAnimation: CARTA.IStopAnimation[];
+    animationFlowControl: CARTA.IAnimationFlowControl[];
     setImageChannel: CARTA.ISetImageChannels[];
+    reverseAnimation: CARTA.IStartAnimation[];
+    blinkAnimation: CARTA.IStartAnimation;
 };
 
 let assertItem: AssertItem = {
@@ -90,15 +92,35 @@ let assertItem: AssertItem = {
             },
         ],
     stopAnimation:
-    {
-        fileId: 0,
-        endFrame: { channel: 10, stokes: 0 },
-    },
+        [
+            {
+                fileId: 0,
+                endFrame: { channel: 10, stokes: 0 },
+            },
+            {
+                fileId: 0,
+                endFrame: { channel: 19, stokes: 0 },
+            },
+            {
+                fileId: 0,
+                endFrame: { channel: 10, stokes: 0 },
+            },
+        ],
     animationFlowControl:
-    {
-        fileId: 0,
-        animationId: 0,
-    },
+        [
+            {
+                fileId: 0,
+                animationId: 1,
+            },
+            {
+                fileId: 0,
+                animationId: 2,
+            },
+            {
+                fileId: 0,
+                animationId: 3,
+            },
+        ],
     setImageChannel:
         [
             {
@@ -112,7 +134,74 @@ let assertItem: AssertItem = {
                     compressionQuality: 11,
                 },
             },
-        ]
+            {
+                fileId: 0,
+                channel: 19,
+                stokes: 0,
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                },
+            },
+            {
+                fileId: 0,
+                channel: 10,
+                stokes: 0,
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                },
+            },
+        ],
+    // reverseAnimation:
+    //     [
+    //         {
+    //             fileId: 0,
+    //             startFrame: { channel: 20, stokes: 0 },
+    //             firstFrame: { channel: 10, stokes: 0 },
+    //             lastFrame: { channel: 20, stokes: 0 },
+    //             deltaFrame: { channel: 1, stokes: 0 },
+    //             requiredTiles: {
+    //                 fileId: 0,
+    //                 tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+    //                 compressionType: CARTA.CompressionType.ZFP,
+    //                 compressionQuality: 9,
+    //             },
+    //             reverse: true,
+    //         },
+    //         // {
+    //         //     fileId: 0,
+    //         //     startFrame: { channel: 20, stokes: 0 },
+    //         //     firstFrame: { channel: 10, stokes: 0 },
+    //         //     lastFrame: { channel: 20, stokes: 0 },
+    //         //     deltaFrame: { channel: -1, stokes: 0 },
+    //         //     requiredTiles: {
+    //         //         fileId: 0,
+    //         //         tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+    //         //         compressionType: CARTA.CompressionType.ZFP,
+    //         //         compressionQuality: 9,
+    //         //     },
+    //         // },
+    //     ],
+    // blinkAnimation:
+    // {
+    //     fileId: 0,
+    //     startFrame: { channel: 3, stokes: 0 },
+    //     firstFrame: { channel: 3, stokes: 0 },
+    //     lastFrame: { channel: 10, stokes: 0 },
+    //     deltaFrame: { channel: 7, stokes: 0 },
+    //     requiredTiles: {
+    //         fileId: 0,
+    //         tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+    //         compressionType: CARTA.CompressionType.ZFP,
+    //         compressionQuality: 9,
+    //     },
+    //     looping: true,
+    // },
 };
 
 describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
@@ -136,6 +225,7 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
 
         describe(`(Step 1) Initialization: the open image"`, () => {
             test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                await Connection.send(CARTA.CloseFile, { fileId: 0 });
                 await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
                 await Connection.receiveAny()
                 await Connection.receiveAny() // OpenFileAck | RegionHistogramData
@@ -168,11 +258,11 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 let SAAck = await Connection.receive(CARTA.StartAnimationAck);
                 expect(SAAck.success).toBe(true);
 
-                for (let i = 0; i < assertItem.stopAnimation.endFrame.channel; i++) {
+                for (let i = 0; i < assertItem.stopAnimation[0].endFrame.channel; i++) {
                     AnimateStreamData.push(await Connection.stream(16) as AckStream);
                     await Connection.send(CARTA.AnimationFlowControl,
                         {
-                            ...assertItem.animationFlowControl,
+                            ...assertItem.animationFlowControl[0],
                             receivedFrame: {
                                 channel: AnimateStreamData[i].RasterTileData[0].channel,
                                 stokes: 0
@@ -184,13 +274,13 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                     sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
                 };
 
-                await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation);
+                await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[0]);
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[0])
                 let lastRasterImageData = await Connection.stream(14) as AckStream;
                 // console.log(lastRasterImageData); // RasterTileData * 12 + RasterTileSync *2 (start & end)
                 // console.log(AnimateStreamData); // RasterTileData * 12 + SpatialProfileData * 1 + RegionHistogramData * 1 + RasterTileSync *2 (start & end)
                 // console.log(sequence); // show looping sequence
-                expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation.endFrame.channel);
+                expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation[0].endFrame.channel);
 
             }, playImageTimeout)
 
@@ -210,28 +300,35 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[1],
                     looping: true,
+                    reverse: false,
+                    frameRate: 5,
                 });
-                // await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
                 await Connection.receive(CARTA.StartAnimationAck);
-                for (let i = 0; i < 2 * Math.abs(assertItem.startAnimation[1].lastFrame.channel - assertItem.startAnimation[1].firstFrame.channel) + 1; i++) {
+                for (let i = 0; i < 2 * Math.abs(assertItem.startAnimation[1].lastFrame.channel - assertItem.startAnimation[1].firstFrame.channel + 1); i++) {
                     AnimateStreamData.push(await Connection.stream(16) as AckStream);
                     await Connection.send(CARTA.AnimationFlowControl,
                         {
-                            ...assertItem.animationFlowControl,
+                            ...assertItem.animationFlowControl[1],
                             receivedFrame: {
                                 channel: AnimateStreamData[i].RasterTileData[0].channel,
                                 stokes: 0,
-                                requiredTiles: assertItem.addTilesReq[1],
                             },
                             timestamp: Long.fromNumber(Date.now()),
                         }
                     );
                     sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
-                }
-                await Connection.send(CARTA.StopAnimation, assertItem.startAnimation);
-                await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[0])
-                let lastRasterImageData = await Connection.stream(14) as AckStream;
-                expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation.endFrame.channel);
+                };
+                // console.log(AnimateStreamData); // RasterTileData * 12 + SpatialProfileData * 1 + RegionHistogramData * 1 + RasterTileSync *2 (start & end)
+
+                await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[1]);
+                await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[1])
+                let lastRasterImageData = await Connection.stream(16) as AckStream;
+                // console.log(lastRasterImageData); // RasterTileData * 12 + SpatialProfileData * 1 + RegionHistogramData * 1 + RasterTileSync *2 (start & end)
+                sequence.push(lastRasterImageData.RasterTileData[0].channel);
+                // console.log(sequence)
+
+                expect(sequence[sequence.length - 1]).toEqual(assertItem.stopAnimation[1].endFrame.channel);
             }, playImageTimeout);
 
             test(`Received image channels should be in sequence`, async () => {
@@ -245,82 +342,124 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
 
         });
 
-        describe(`(Step 4 )Play some images until stop`, () => {
-            let AnimateStreamData: AckStream[] = [];
-            test(`Image should return one after one`, async () => {
-                await Connection.send(CARTA.StartAnimation, {
-                    ...assertItem.startAnimation[0],
-                    looping: true,
-                    reverse: false,
-                    frameRate: 5,
-                });
-                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
-                await Connection.receive(CARTA.StartAnimationAck);
+        // describe(`(Step 4 )Play some images until stop`, () => {
+        //     let AnimateStreamData: AckStream[] = [];
+        //     let lastRasterImageData: AckStream;
+        //     test(`Image should return one after one`, async () => {
+        //         await Connection.send(CARTA.StartAnimation, {
+        //             ...assertItem.startAnimation[0],
+        //             looping: true,
+        //             reverse: false,
+        //             frameRate: 5,
+        //         });
+        //         await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+        //         await Connection.receive(CARTA.StartAnimationAck);
 
-                for (let i = 0; i < assertItem.stopAnimation.endFrame.channel; i++) {
-                    AnimateStreamData.push(await Connection.stream(16) as AckStream);
-                    await Connection.send(CARTA.AnimationFlowControl,
-                        {
-                            ...assertItem.animationFlowControl,
-                            receivedFrame: {
-                                channel: AnimateStreamData[i].RasterTileData[0].channel,
-                                stokes: 0
-                            },
-                            timestamp: Long.fromNumber(Date.now()),
-                        }
-                    );
-                    // console.log(AnimateStreamData[i].RasterTileData[0].channel);
-                };
+        //         for (let i = 0; i < assertItem.stopAnimation[2].endFrame.channel; i++) {
+        //             AnimateStreamData.push(await Connection.stream(16) as AckStream);
+        //             await Connection.send(CARTA.AnimationFlowControl,
+        //                 {
+        //                     ...assertItem.animationFlowControl[2],
+        //                     receivedFrame: {
+        //                         channel: AnimateStreamData[i].RasterTileData[0].channel,
+        //                         stokes: 0
+        //                     },
+        //                     timestamp: Long.fromNumber(Date.now()),
+        //                 }
+        //             );
+        //             // console.log(AnimateStreamData[i].RasterTileData[0].channel);
+        //         };
+        //         await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[2]);
+        //         await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[2])
+        //         lastRasterImageData = await Connection.stream(16) as AckStream;
+        //         console.log(lastRasterImageData)
 
-            }, playImageTimeout);
+        //     }, playImageTimeout);
 
-            test(`Last image on channel${JSON.stringify(assertItem.stopAnimation.endFrame)} should receive after stop`, async () => {
-                await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation);
-                await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[0])
-                let lastRasterImageData = await Connection.stream(14) as AckStream;
-                expect(lastRasterImageData.RasterTileData[0].channel).toEqual(assertItem.stopAnimation.endFrame.channel);
-            });
-        });
+        //     test(`Last image on channel${JSON.stringify(assertItem.stopAnimation[2].endFrame)} should receive after stop`, async () => {
+        //         console.log(lastRasterImageData.RasterTileData[0].channel);
+        //         // expect(lastRasterImageData.RasterTileData[0].channel).toEqual(assertItem.stopAnimation[2].endFrame.channel);
+        //     });
+        // });
 
-        describe(`(Step 5) Play images round-trip`, () => {
-            let AnimateStreamData: AckStream[] = [];
-            let sequence: number[] = [];
-            test(`Image should return one after one`, async () => {
-                await Connection.send(CARTA.StartAnimation, {
-                    ...assertItem.startAnimation[0],
-                    reverse: true,
-                    requiredTiles: assertItem.addTilesReq[1]
-                });
-                // await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
-                await Connection.receive(CARTA.StartAnimationAck);
+        // describe(`(Step 5) Play images round-trip`, () => {
+        //     let AnimateStreamData: AckStream[] = [];
+        //     let sequence: number[] = [];
+        //     test(`Image should return one after one`, async () => {
+        //         await Connection.send(CARTA.StartAnimation, {
+        //             ...assertItem.startAnimation[0],
+        //             reverse: true,
+        //         });
+        //         await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+        //         await Connection.receive(CARTA.StartAnimationAck);
 
-                for (let i = 0; i < 3 * Math.abs(assertItem.startAnimation[0].lastFrame.channel - assertItem.startAnimation[0].firstFrame.channel); i++) {
-                    AnimateStreamData.push(await Connection.stream(16) as AckStream);
-                    await Connection.send(CARTA.AnimationFlowControl,
-                        {
-                            ...assertItem.animationFlowControl,
-                            receivedFrame: {
-                                channel: AnimateStreamData[i].RasterTileData[0].channel,
-                                stokes: 0
-                            },
-                            timestamp: Long.fromNumber(Date.now()),
-                        }
-                    );
-                    sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
-                }
-                await Connection.send(CARTA.StopAnimation, CARTA.StopAnimation);
-                let lastRasterImageData = await Connection.stream(14) as AckStream;
-                // console.log(sequence);
+        //         for (let i = 0; i < 3 * Math.abs(assertItem.startAnimation[0].lastFrame.channel - assertItem.startAnimation[0].firstFrame.channel); i++) {
+        //             // console.log(i);
+        //             AnimateStreamData.push(await Connection.stream(16) as AckStream);
+        //             await Connection.send(CARTA.AnimationFlowControl,
+        //                 {
+        //                     ...assertItem.animationFlowControl,
+        //                     receivedFrame: {
+        //                         channel: AnimateStreamData[i].RasterTileData[0].channel,
+        //                         stokes: 0,
+        //                     },
+        //                     timestamp: Long.fromNumber(Date.now()),
+        //                 }
+        //             );
+        //             sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
+        //         };
+        //         await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[2]);
+        //         await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[2])
+        //         let lastRasterImageData = await Connection.stream(20) as AckStream;
+        //         console.log(lastRasterImageData)
+        //         console.log(sequence);
 
-            }, playImageTimeout);
+        //     }, playImageTimeout);
 
-            test(`Received image channels should be in sequence and then reverse:`, async () => {
-                console.log(`Channel index in roundtrip: ${sequence}`);
-                let previous: number = assertItem.startAnimation[0].lastFrame.channel;
-                expect(Math.abs(sequence[sequence.length - 1] - previous)).toEqual(0);
-            });
-        });
+        //     // test(`Received image channels should be in sequence and then reverse:`, async () => {
+        //     //     console.log(`Channel index in roundtrip: ${sequence}`);
+        //     //     let previous: number = assertItem.startAnimation[0].lastFrame.channel;
+        //     //     // expect(Math.abs(sequence[sequence.length - 1] - previous)).toEqual(0);
+        //     // });
+        // });
 
+        // assertItem.reverseAnimation.map((animation, index) => {
+        //     describe(`(Step 6) Play all images backwardly using method${index + 1}`, () => {
+        //         let AnimateStreamData: AckStream[] = [];
+        //         let sequence: number[] = [];
+        //         test(`Image should return one after one`, async () => {
+        //             await Connection.send(CARTA.StartAnimation, animation);
+        //             await Connection.receive(CARTA.StartAnimationAck);
+        //             for (let i = 0; i < Math.abs(animation.lastFrame.channel - animation.firstFrame.channel); i++) {
+        //                 AnimateStreamData.push(await Connection.stream(16) as AckStream);
+        //                 await Connection.send(CARTA.AnimationFlowControl,
+        //                     {
+        //                         ...assertItem.animationFlowControl,
+        //                         receivedFrame: {
+        //                             channel: AnimateStreamData[i].RasterTileData[0].channel,
+        //                             stokes: 0
+        //                         },
+        //                         timestamp: Long.fromNumber(Date.now()),
+        //                         animationid: index + 5,
+        //                     }
+        //                 );
+        //                 sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
+        //             }
+        //             await Connection.send(CARTA.StopAnimation, CARTA.StopAnimation);
+        //             await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[1])
+        //             let lastRasterImageData = await Connection.stream(14) as AckStream;
+        //             console.log(AnimateStreamData[0].RasterTileData);
+        //             console.log(sequence);
+        //         }, playImageTimeout);
+
+        //         test(`Received image channels should be in sequence`, async () => {
+        //             console.log(`Backward channel index: ${sequence}`);
+        //             AnimateStreamData.map((imageData, index) => {
+        //                 expect(sequence[index]).toEqual(animation.startFrame.channel - index);
+        //             });
+        //         });
+        //     });
+        // });
     });
 
     test(`close file`, async () => {

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -378,15 +378,17 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 };
                 await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation[2]);
                 await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[2]);
+
                 lastRasterImageData = await Connection.stream(16) as AckStream;
-                // console.log(lastRasterImageData);
+                console.log(lastRasterImageData);
                 // console.log(AnimateStreamData);
 
             }, playImageTimeout);
 
             test(`Last image on channel${JSON.stringify(assertItem.stopAnimation[2].endFrame)} should receive after stop`, async () => {
                 // console.log(lastRasterImageData.RasterTileData[0].channel);
-                expect(lastRasterImageData.RasterTileData[0].channel).toEqual(assertItem.stopAnimation[2].endFrame.channel);
+                expect(lastRasterImageData.RasterTileData[0].channel).toBeGreaterThanOrEqual(assertItem.stopAnimation[2].endFrame.channel);
+                expect(lastRasterImageData.RasterTileData[0].channel).toBeLessThan(assertItem.stopAnimation[2].endFrame.channel + 2.);
             });
         });
 

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -1,0 +1,208 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+import { async } from "q";
+import * as Long from "long";
+import { Field } from "protobufjs";
+
+let testServerUrl: string = config.serverURL;
+let testSubdirectory: string = config.path.QA;
+let connectTimeout: number = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
+let playImageTimeout: number = config.timeout.playImages;
+
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
+    startAnimation: CARTA.IStartAnimation[];
+    stopAnimation: CARTA.IStopAnimation;
+    animationFlowControl: CARTA.IAnimationFlowControl;
+    setImageChannel: CARTA.ISetImageChannels[];
+};
+
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "M17_SWex.image",
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: [
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+        },
+        {
+            fileId: 0,
+            compressionQuality: 9,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+        },
+    ],
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: ["x", "y"]
+    },
+    startAnimation:
+        [
+            {
+                fileId: 0,
+                startFrame: { channel: 1, stokes: 0 },
+                firstFrame: { channel: 0, stokes: 0 },
+                lastFrame: { channel: 24, stokes: 0 },
+                deltaFrame: { channel: 1, stokes: 0 },
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 9,
+                },
+            },
+            // {
+            //     fileId: 0,
+            //     startFrame: { channel: 19, stokes: 0 },
+            //     firstFrame: { channel: 9, stokes: 0 },
+            //     lastFrame: { channel: 19, stokes: 0 },
+            //     deltaFrame: { channel: -1, stokes: 0 },
+            //     requiredTiles: {
+            //         fileId: 0,
+            //         tiles: [33554432, 33558528, 33562624, 33566720, 33554433, 33558529, 33562625, 33566721, 33554434, 33558530, 33562626, 33566722],
+            //         compressionType: CARTA.CompressionType.ZFP,
+            //         compressionQuality: 9,
+            //     },
+            // },
+        ],
+    stopAnimation:
+    {
+        fileId: 0,
+        endFrame: { channel: 10, stokes: 0 },
+    },
+    animationFlowControl:
+    {
+        fileId: 0,
+        animationId: 0,
+    },
+    setImageChannel:
+        [
+            {
+                fileId: 0,
+                channel: 10,
+                stokes: 0,
+                requiredTiles: {
+                    fileId: 0,
+                    tiles: [33558529, 33558528, 33562625, 33554433, 33562624, 33558530, 33554432, 33562626, 33554434, 33566721, 33566720, 33566722],
+                    compressionType: CARTA.CompressionType.ZFP,
+                    compressionQuality: 11,
+                },
+            },
+        ]
+};
+
+describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
+
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.send(CARTA.RegisterViewer, assertItem.register);
+        await Connection.receive(CARTA.RegisterViewerAck);
+    }, connectTimeout);
+
+    test(`(Step 0) Connection open? | `, () => {
+        expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
+    });
+
+    describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+        beforeAll(async () => {
+            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+        }, connectTimeout);
+
+        describe(`(Step 1) Initialization: the open image"`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                await Connection.receiveAny()
+                await Connection.receiveAny() // OpenFileAck | RegionHistogramData
+            }, openFileTimeout);
+
+            let ack: AckStream;
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
+                await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
+
+                ack = await Connection.stream(15) as AckStream;
+                // console.log(ack); // RasterTileData * 12 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
+                expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq[0].tiles.length);
+            }, playImageTimeout);
+
+        });
+
+        describe(`(Step 2):Play all images forwardly with looping`, () => {
+            let AnimateStreamData: AckStream[] = [];
+            let sequence: number[] = [];
+            test(`Image should return one after one and last channel is correct:`, async () => {
+                await Connection.send(CARTA.StartAnimation, {
+                    ...assertItem.startAnimation[0],
+                    looping: true,
+                    reverse: false,
+                    frameRate: 5,
+                });
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+                let SAAck = await Connection.receive(CARTA.StartAnimationAck);
+                expect(SAAck.success).toBe(true);
+
+                for (let i = 0; i < assertItem.stopAnimation.endFrame.channel; i++) {
+                    AnimateStreamData.push(await Connection.stream(16) as AckStream);
+                    await Connection.send(CARTA.AnimationFlowControl,
+                        {
+                            ...assertItem.animationFlowControl,
+                            receivedFrame: {
+                                channel: AnimateStreamData[i].RasterTileData[0].channel,
+                                stokes: 0
+                            },
+                            timestamp: Long.fromNumber(Date.now()),
+                        }
+                    );
+                    // console.log(AnimateStreamData[i].Responce) // In principle, each channel should have RasterTileSync *2 (start & end)
+                    sequence.push(AnimateStreamData[i].RasterTileData[0].channel);
+                };
+
+                await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation);
+                await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel[0])
+                let lastRasterImageData = await Connection.stream(14) as AckStream;
+                // console.log(lastRasterImageData); // RasterTileData * 12 + RasterTileSync *2 (start & end)
+                // console.log(AnimateStreamData); // RasterTileData * 12 + SpatialProfileData * 1 + RegionHistogramData * 1 + RasterTileSync *2 (start & end)
+                // console.log(sequence); // show looping sequence
+                expect(sequence[assertItem.stopAnimation.endFrame.channel - 1]).toEqual(assertItem.stopAnimation.endFrame.channel);
+
+            }, playImageTimeout)
+        });
+
+
+
+    });
+
+    test(`close file`, async () => {
+        await Connection.send(CARTA.CloseFile, { fileId: 0 });
+    }, connectTimeout);
+
+    afterAll(() => Connection.close());
+
+});

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -9,7 +9,7 @@ let testServerUrl: string = config.serverURL;
 let testSubdirectory: string = config.path.QA;
 let connectTimeout: number = config.timeout.connection;
 let openFileTimeout: number = config.timeout.openFile;
-let playImageTimeout: number = config.timeout.playImages;
+let playImageTimeout: number = 10000;//config.timeout.playImages;
 
 interface AssertItem {
     register: CARTA.IRegisterViewer;
@@ -234,6 +234,10 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
         expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
     });
 
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
     describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
@@ -315,6 +319,8 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
+                await sleep(3000);
+                console.log('sleep!')
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[1],
                     looping: true,
@@ -364,6 +370,8 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let lastRasterImageData: AckStream;
             test(`Image should return one after one`, async () => {
+                await sleep(3000);
+                console.log('sleep!')
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[0],
                     looping: true,
@@ -408,6 +416,8 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
+                await sleep(3000);
+                console.log('sleep!')
                 await Connection.send(CARTA.StartAnimation, {
                     ...assertItem.startAnimation[0],
                     reverse: true,
@@ -451,6 +461,8 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
                 let AnimateStreamData: AckStream[] = [];
                 let sequence: number[] = [];
                 test(`Image should return one after one`, async () => {
+                    await sleep(3000);
+                    console.log('sleep!')
                     await Connection.send(CARTA.StartAnimation, animation);
                     await Connection.receive(CARTA.StartAnimationAck);
                     for (let i = 0; i < Math.abs(animation.lastFrame.channel - animation.firstFrame.channel); i++) {
@@ -483,10 +495,12 @@ describe("ANIMATOR_PLAYBACK test: Testing animation playback", () => {
             });
         });
 
-        describe(`Blink images bewteen ${assertItem.blinkAnimation.firstFrame.channel} and ${assertItem.blinkAnimation.lastFrame.channel}`, () => {
+        describe(`(Step 7) Blink images bewteen ${assertItem.blinkAnimation.firstFrame.channel} and ${assertItem.blinkAnimation.lastFrame.channel}`, () => {
             let AnimateStreamData: AckStream[] = [];
             let sequence: number[] = [];
             test(`Image should return one after one`, async () => {
+                await sleep(3000);
+                console.log('sleep!')
                 await Connection.send(CARTA.StartAnimation, assertItem.blinkAnimation);
                 await Connection.receive(CARTA.StartAnimationAck);
                 for (let i = 0; i < 11; i++) {

--- a/src/test/ANIMATOR_PLAYBACK-v12.test.ts
+++ b/src/test/ANIMATOR_PLAYBACK-v12.test.ts
@@ -1,9 +1,7 @@
 import { CARTA } from "carta-protobuf";
 import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
-import { async } from "q";
 import * as Long from "long";
-import { Field } from "protobufjs";
 
 let testServerUrl: string = config.serverURL;
 let testSubdirectory: string = config.path.QA;

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -25,7 +25,9 @@
         "region": 500,
         "import": 500,
         "export": 500,
-        "resume": 3000
+        "resume": 3000,
+        "sleep": 3000,
+        "playAnimator": 10000
     },
     "repeat": {
         "concurrent": 10,


### PR DESCRIPTION
#90 
I found there are many channels/tiles to run, in order to prevent the busyness of the backend.
I am adding a sleep 3000ms function before sending a startanimator for each test and also setting the playImageTimeout from 8000ms to 10000ms (few tests running inside the IAA network cost about 7500ms, which is quite close to the threshold we set before).

After adding a sleep function, the passed rate can reach 100/100.
The passed rate is only 32/100 without a sleep function.

Document (ANIMATOR_PLAYBACK-v12) is [here](https://docs.google.com/document/d/1h098N2xCB4Rburjm8G9XTcN3MqfMjVhwt_Qrpy-69Os/edit#) 
