### PR TITLE
Mylin/#113 cube histogram [DO NOT merge this PR, may have submodule contamination]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "protobuf"]
-	path = protobuf
-	url = https://github.com/CARTAvis/carta-protobuf.git

--- a/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
@@ -1,10 +1,11 @@
 import { CARTA } from "carta-protobuf";
-import { Client } from "./CLIENT";
+import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
+let openFileTimeout: number = config.timeout.openFile;
 let readFileTimeout = config.timeout.readFile;
 let messageReturnTimeout = config.timeout.readFile;
 let cubeHistogramTimeout = config.timeout.cubeHistogram;
@@ -15,8 +16,10 @@ interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
 }
 interface AssertItem {
     register: CARTA.IRegisterViewer;
-    fileOpenGroup: CARTA.IOpenFile[];
-    setImageChannels: CARTA.ISetImageChannels;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setSpatialReq: CARTA.ISetSpatialRequirements;
     setHistogramRequirements: CARTA.ISetHistogramRequirements;
     regionHistogramData: IRegionHistogramDataExt;
     precisionDigits: number;
@@ -26,32 +29,27 @@ let assertItem: AssertItem = {
         sessionId: 0,
         clientFeatureFlags: 5,
     },
-    fileOpenGroup: [
-        {
-            directory: testSubdirectory,
-            file: "supermosaic.10.fits",
-            fileId: 0,
-            hdu: "",
-            renderMode: CARTA.RenderMode.RASTER,
-        },
-        {
-            directory: testSubdirectory,
-            file: "supermosaic.10.hdf5",
-            fileId: 0,
-            hdu: "",
-            renderMode: CARTA.RenderMode.RASTER,
-        },
-    ],
-    setImageChannels: {
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "supermosaic.10.fits",
         fileId: 0,
-        channel: 0,
-        stokes: 0,
-        requiredTiles: {
-            fileId: 0,
-            compressionType: CARTA.CompressionType.ZFP,
-            compressionQuality: 11,
-            tiles: [0],
-        },
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setSpatialReq: {
+        fileId: 0,
+        regionId: 0,
+        spatialProfiles: ["x", "y"]
     },
     setHistogramRequirements: {
         fileId: 0,
@@ -77,41 +75,43 @@ let assertItem: AssertItem = {
 };
 
 describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogram", () => {
-    assertItem.fileOpenGroup.map((fileOpen, index) => {
-        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.fileOpenGroup[index].file}" to set image view`, () => {
-            let Connection: Client;
-            beforeAll(async () => {
-                Connection = new Client(testServerUrl);
-                await Connection.open();
-                await Connection.send(CARTA.RegisterViewer, assertItem.register);
-                await Connection.receive(CARTA.RegisterViewerAck);
-            }, connectTimeout);
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.send(CARTA.RegisterViewer, assertItem.register);
+        await Connection.receive(CARTA.RegisterViewerAck);
+    }, connectTimeout);
 
-            test(`(Step 0) Connection open? | `, () => {
-                expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
-            });
+    test(`(Step 0) Connection open? | `, () => {
+        expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
+    });
 
-            // describe(`(Step 1) Initialization: the open image`, () => {
-            //     test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
-            //         await Connection.send(CARTA.CloseFile, { fileId: 0 });
-            //         await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            //         await Connection.receiveAny()
-            //         await Connection.receiveAny() // OpenFileAck | RegionHistogramData
-            //     }, openFileTimeout);
+    describe(`Go to "${assertItem.fileOpen.directory}" folder`, () => {
+        beforeAll(async () => {
+            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+        }, connectTimeout);
 
-            //     let ack: AckStream;
-            //     test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
-            //         await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
-            //         await Connection.send(CARTA.SetCursor, assertItem.setCursor);
-            //         await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
+        describe(`(Step 1) Initialization: the open image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                await Connection.send(CARTA.CloseFile, { fileId: 0 });
+                await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                await Connection.receiveAny()
+                await Connection.receiveAny() // OpenFileAck | RegionHistogramData
+            }, openFileTimeout);
 
-            //         ack = await Connection.stream(15) as AckStream;
-            //         // console.log(ack); // RasterTileData * 12 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
-            //         expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq[0].tiles.length);
-            //     }, playImageTimeout);
+            let ack: AckStream;
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                // await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
 
-            // });
+                ack = await Connection.stream(assertItem.addTilesReq.tiles.length + 3) as AckStream;
+                console.log(ack); // RasterTileData * 1 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
+                expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq.tiles.length);
+            }, readFileTimeout);
 
         });
     });
+
 });

--- a/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
@@ -1,0 +1,117 @@
+import { CARTA } from "carta-protobuf";
+import { Client } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let readFileTimeout = config.timeout.readFile;
+let messageReturnTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+}
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    fileOpenGroup: CARTA.IOpenFile[];
+    setImageChannels: CARTA.ISetImageChannels;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    fileOpenGroup: [
+        {
+            directory: testSubdirectory,
+            file: "supermosaic.10.fits",
+            fileId: 0,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        {
+            directory: testSubdirectory,
+            file: "supermosaic.10.hdf5",
+            fileId: 0,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+    ],
+    setImageChannels: {
+        fileId: 0,
+        channel: 0,
+        stokes: 0,
+        requiredTiles: {
+            fileId: 0,
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 11,
+            tiles: [0],
+        },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        histograms: [
+            {
+                channel: -2,
+                numBins: 2775,
+                binWidth: 0.7235205769538879,
+                firstBinCenter: -1773.2998046875,
+            },
+        ],
+        lengthOfHistogramBins: 2775,
+        binValues: [{ index: 2500, value: 9359604 },],
+    },
+    precisionDigits: 4,
+};
+
+describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogram", () => {
+    assertItem.fileOpenGroup.map((fileOpen, index) => {
+        describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.fileOpenGroup[index].file}" to set image view`, () => {
+            let Connection: Client;
+            beforeAll(async () => {
+                Connection = new Client(testServerUrl);
+                await Connection.open();
+                await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                await Connection.receive(CARTA.RegisterViewerAck);
+            }, connectTimeout);
+
+            test(`(Step 0) Connection open? | `, () => {
+                expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
+            });
+
+            // describe(`(Step 1) Initialization: the open image`, () => {
+            //     test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+            //         await Connection.send(CARTA.CloseFile, { fileId: 0 });
+            //         await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+            //         await Connection.receiveAny()
+            //         await Connection.receiveAny() // OpenFileAck | RegionHistogramData
+            //     }, openFileTimeout);
+
+            //     let ack: AckStream;
+            //     test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+            //         await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
+            //         await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+            //         await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
+
+            //         ack = await Connection.stream(15) as AckStream;
+            //         // console.log(ack); // RasterTileData * 12 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
+            //         expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq[0].tiles.length);
+            //     }, playImageTimeout);
+
+            // });
+
+        });
+    });
+});

--- a/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM-v15.test.ts
@@ -167,5 +167,5 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
 
         });
     });
-
+    afterAll(() => Connection.close());
 });

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION-v15.test.ts
@@ -1,0 +1,176 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+let messageReturnTimeout = config.timeout.readFile;
+let cancelTimeout = config.timeout.cancel;
+
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+    mean: number;
+    stdDev: number;
+}
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    cancelHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "supermosaic.10.fits",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    cancelHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        histograms: [
+            {
+                channel: -2,
+                numBins: 2775,
+                binWidth: 0.7235205769538879,
+                firstBinCenter: -1773.2998046875,
+            },
+        ],
+        lengthOfHistogramBins: 2775,
+        binValues: [{ index: 2500, value: 9359604 },],
+        mean: 18.742310255027036,
+        stdDev: 22.534721826342878,
+    },
+    precisionDigits: 4,
+};
+
+describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogram", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.send(CARTA.RegisterViewer, assertItem.register);
+        await Connection.receive(CARTA.RegisterViewerAck);
+    }, connectTimeout);
+
+    test(`(Step 0) Connection open? | `, () => {
+        expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
+    });
+
+    describe(`Go to "${assertItem.fileOpen.directory}" folder`, () => {
+        beforeAll(async () => {
+            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+        }, connectTimeout);
+
+        describe(`(Step 0) Initialization: the open image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                await Connection.send(CARTA.CloseFile, { fileId: 0 });
+                await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                await Connection.receiveAny()
+                await Connection.receiveAny() // OpenFileAck | RegionHistogramData
+            }, openFileTimeout);
+
+            let ack: AckStream;
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                // await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
+
+                ack = await Connection.stream(assertItem.addTilesReq.tiles.length + 3) as AckStream;
+                console.log(ack); // RasterTileData * 1 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
+                expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq.tiles.length);
+            }, readFileTimeout);
+
+            let ReceiveProgress: number;
+            let RegionHistogramDataTemp: CARTA.RegionHistogramData;
+            describe(`Set histogram requirements:`, () => {
+                test(`(Step1) "${assertItem.fileOpen.file}" REGION_HISTOGRAM_DATA should arrive completely within 3000 ms:`, async () => {
+                    await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
+                    RegionHistogramDataTemp = await Connection.receive(CARTA.RegionHistogramData);
+                    ReceiveProgress = RegionHistogramDataTemp.progress;
+                }, 3000);
+
+                test(`(Step2) REGION_HISTOGRAM_DATA.progress > 0 and REGION_HISTOGRAM_DATA.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
+                    expect(ReceiveProgress).toBeGreaterThan(0);
+                    expect(RegionHistogramDataTemp.regionId).toEqual(assertItem.regionHistogramData.regionId);
+                    console.log('Step2 progress:', ReceiveProgress)
+                });
+
+                test(`(Step3) The second REGION_HISTOGRAM_DATA should arrive and REGION_HISTOGRAM_DATA.progress > previous one `, async () => {
+                    await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
+                    RegionHistogramDataTemp = await Connection.receive(CARTA.RegionHistogramData);
+                    ReceiveProgress = RegionHistogramDataTemp.progress;
+                    console.log('' + assertItem.fileOpen.file + ' Region Histogram progress :', ReceiveProgress);
+                }, readFileTimeout);
+
+                test("(Step4) Assert no more REGION_HISTOGRAM_DATA returns", async () => {
+                    /// After 5 seconds, the request of the per-cube histogram is cancelled.
+                    await new Promise(end => setTimeout(() => end(), cancelTimeout));
+                    await Connection.send(CARTA.SetHistogramRequirements, assertItem.cancelHistogramRequirements);
+                    await Connection.receive(CARTA.RegionHistogramData, messageReturnTimeout, false);
+                }, readFileTimeout + messageReturnTimeout + cancelTimeout);
+
+                test("(Step5) Assert a renew REGION_HISTOGRAM_DATA as the progress = 1.0", async () => {
+                    /// Then request to get the per-cube histogram again in 2 seconds.
+                    await new Promise(end => setTimeout(() => end(), 2000));
+                    await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
+                    while (ReceiveProgress != 1) {
+                        RegionHistogramDataTemp = await Connection.receive(CARTA.RegionHistogramData, messageReturnTimeout, true);
+                        ReceiveProgress = RegionHistogramDataTemp.progress
+                        console.warn('' + assertItem.fileOpen.file + ' Region Histogram progress :', ReceiveProgress)
+                        if (ReceiveProgress === 1.0) {
+                            expect(ReceiveProgress).toEqual(1);
+                            expect(RegionHistogramDataTemp.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
+                            expect(RegionHistogramDataTemp.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                            expect(RegionHistogramDataTemp.histograms[0].bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                            expect(RegionHistogramDataTemp.histograms[0].channel).toEqual(assertItem.regionHistogramData.histograms[0].channel);
+                            expect(RegionHistogramDataTemp.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
+                            expect(RegionHistogramDataTemp.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
+                            expect(RegionHistogramDataTemp.histograms[0].mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                            expect(RegionHistogramDataTemp.histograms[0].stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                            expect(RegionHistogramDataTemp.regionId).toEqual(assertItem.regionHistogramData.regionId);
+                        };
+                    };
+                }, cubeHistogramTimeout);
+            });
+
+        });
+    });
+    afterAll(() => Connection.close());
+});

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5-v15.test.ts
@@ -156,5 +156,5 @@ describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogr
 
         });
     });
-
+    afterAll(() => Connection.close());
 });

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5-v15.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5-v15.test.ts
@@ -1,0 +1,160 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+let readFileTimeout = config.timeout.readFile;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
+
+interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
+    lengthOfHistogramBins: number;
+    binValues: { index: number, value: number }[];
+    mean: number;
+    stdDev: number;
+}
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    fileOpen: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+    regionHistogramData: IRegionHistogramDataExt;
+    precisionDigits: number;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: "supermosaic.10.hdf5",
+        fileId: 0,
+        hdu: "0",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [0],
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1, y: 1 },
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+    regionHistogramData: {
+        regionId: -2,
+        histograms: [
+            {
+                channel: -2,
+                numBins: 2775,
+                binWidth: 0.7235205573004645,
+                firstBinCenter: -1773.2998608150997,
+            },
+        ],
+        lengthOfHistogramBins: 2775,
+        binValues: [{ index: 2500, value: 9359604 },],
+        mean: 18.742310241547514,//18.742310241547514 for socketdev; 18.743059611332498 for socketicd
+        stdDev: 22.534722680160574,//22.534722680160574 for socketdev; 22.376087536494833 for socketicd
+    },
+    precisionDigits: 4,
+};
+
+describe("PER_CUBE_HISTOGRAM tests: Testing calculations of the per-cube histogram", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.send(CARTA.RegisterViewer, assertItem.register);
+        await Connection.receive(CARTA.RegisterViewerAck);
+    }, connectTimeout);
+
+    test(`(Step 0) Connection open? | `, () => {
+        expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
+    });
+
+    describe(`Go to "${assertItem.fileOpen.directory}" folder`, () => {
+        beforeAll(async () => {
+            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+        }, connectTimeout);
+
+        describe(`(Step 0) Initialization: the open image`, () => {
+            test(`OPEN_FILE_ACK and REGION_HISTOGRAM_DATA should arrive within ${openFileTimeout} ms`, async () => {
+                await Connection.send(CARTA.CloseFile, { fileId: 0 });
+                await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                await Connection.receiveAny()
+                await Connection.receiveAny() // OpenFileAck | RegionHistogramData
+            }, openFileTimeout);
+
+            let ack: AckStream;
+            test(`return RASTER_TILE_DATA(Stream) and check total length `, async () => {
+                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                // await Connection.send(CARTA.SetSpatialRequirements, assertItem.setSpatialReq);
+
+                ack = await Connection.stream(assertItem.addTilesReq.tiles.length + 3) as AckStream;
+                console.log(ack); // RasterTileData * 1 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)
+                expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq.tiles.length);
+            }, readFileTimeout);
+
+            let ReceiveProgress: number;
+            let RegionHistogramDataTemp: CARTA.RegionHistogramData;
+            describe(`Set histogram requirements:`, () => {
+                test(`(Step1) "${assertItem.fileOpen.file}" REGION_HISTOGRAM_DATA should arrive completely within 400 ms:`, async () => {
+                    await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
+                    RegionHistogramDataTemp = await Connection.receive(CARTA.RegionHistogramData);
+                    ReceiveProgress = RegionHistogramDataTemp.progress;
+                }, 400);
+
+                test(`(Step2) REGION_HISTOGRAM_DATA.progress == 1`, () => {
+                    expect(ReceiveProgress).toBe(1);
+                });
+
+                test(`(Step3) REGION_HISTOGRAM_DATA.histograms.bin_width = ${assertItem.regionHistogramData.histograms[0].binWidth}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
+                });
+
+                test(`(Step4) len(REGION_HISTOGRAM_DATA.histograms.bins) = ${assertItem.regionHistogramData.lengthOfHistogramBins}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                });
+
+                test(`(Step5) REGION_HISTOGRAM_DATA.histograms.bins[2500] = 9359604`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                });
+
+                test(`(Step6) REGION_HISTOGRAM_DATA.histograms.firt_bin_center = ${assertItem.regionHistogramData.histograms[0].firstBinCenter}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
+                });
+
+                test(`(Step7) REGION_HISTOGRAM_DATA.histograms.num_bins = ${assertItem.regionHistogramData.histograms[0].numBins}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
+                });
+
+                test(`(Step8) REGION_HISTOGRAM_DATA.histograms.mean = ${assertItem.regionHistogramData.mean}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                });
+
+                test(`(Step9) REGION_HISTOGRAM_DATA.histograms.stdDev = ${assertItem.regionHistogramData.stdDev}`, () => {
+                    expect(RegionHistogramDataTemp.histograms[0].stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                });
+
+                test(`(Step10) REGION_HISTOGRAM_DATA.histograms.region_id = ${assertItem.regionHistogramData.regionId}`, () => {
+                    expect(RegionHistogramDataTemp.regionId).toEqual(assertItem.regionHistogramData.regionId);
+                });
+            });
+
+        });
+    });
+
+});


### PR DESCRIPTION
#113 
A minor discover when I use "socketicd" for developing:
Different servers (socketdev & socketicd) will return different mean(Step8) & stddev(Step9) in "PER_CUBE_HISTOGRAM_HDF5-v15.test.ts". Difference can reach ~0.159, which is much larger than the digit precision we already set.
But the socketdev passes the values which KS designed in the document, and our main server is socketdev as well. So I think it would be ok.
I am just curious about why they the differences? (but I am testing icd15 for long-term performance, the last update dev branch version of socketicd is (4b0f9a8 5068 2020-07-08 18:48:42 UTC)) 