### PR TITLE
Add functionality for recording the number of threads

### DIFF
--- a/src/action/ExecThread_LoadImage.test.ts
+++ b/src/action/ExecThread_LoadImage.test.ts
@@ -1,0 +1,138 @@
+import { CARTA } from "carta-protobuf";
+
+import { assert } from "console";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testServerUrl: string = config.localHost + ":" + config.port;
+let testSubdirectory: string = config.path.performance;
+let testImage: string = config.image.singleChannel;
+let execTimeout: number = config.timeout.execute;
+let listTimeout: number = config.timeout.listFile;
+let readFileTimeout: number = config.timeout.readLargeImage;
+let imageReload: number = config.repeat.image;
+let monitorPeriod: number = config.wait.monitor;
+let mainThread: number = 4;
+let ompThread: number = 8;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        directory: testSubdirectory,
+        file: testImage,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq:
+    {
+        tiles: [
+            33558529, 33562625, 33558528, 33558530,
+            33554433, 33562624, 33562626, 33554432,
+            33554434, 33566721, 33558531, 33566720,
+            33566722, 33562627, 33554435, 33566723
+        ],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+}
+
+describe("Load Image action: ", () => {
+    let Connection: Client;
+    let cartaBackend: any;
+    let fileNameInit: string =  assertItem.fileOpen.file.substr(assertItem.fileOpen.file.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+    let logFile = fileNameInit + "_loadImage.txt";
+    let usageFile_openFile = fileNameInit + "_openfile_usage.txt";
+    let usageFile_tile = fileNameInit + "_tile_usage.txt";
+    test(`Empty the record files`, async () => {
+        await EmptyTxt(logFile);
+        await EmptyTxt(usageFile_openFile);
+        await EmptyTxt(usageFile_tile);
+    });
+
+    test(`CARTA is ready`, async () => {
+        cartaBackend = await Socket.CartaBackend(
+            logFile,
+            config.port,
+            mainThread,
+            ompThread,
+        );
+        await Wait(config.wait.exec);
+    }, execTimeout + config.wait.exec);
+
+    describe(`Start the action: load image`, () => {
+        test(`Connection is ready`, async () => {
+            Connection = new Client(testServerUrl);
+            await Connection.open();
+            await Connection.send(CARTA.RegisterViewer, assertItem.register);
+            await Connection.receive(CARTA.RegisterViewerAck);
+        }, listTimeout);
+
+        describe(`open the file "${assertItem.fileOpen.file}"`, () => {
+            test(`${imageReload} images data should return`, async () => {
+                for (let index: number = 0; index < imageReload; index++) {
+                    let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                    await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                    await Connection.receiveAny(); // OpenFileAck
+                    clearInterval(monitor.id);
+                    if (monitor.data.cpu.length === 0) {
+                        await AppendTxt(usageFile_openFile, await Usage(cartaBackend.pid));
+                    } else {
+                        await AppendTxt(usageFile_openFile, monitor.data);
+                    }
+
+                    monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                    await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                    await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                    let ack: AckStream;
+                    while (true) {
+                        ack = await Connection.stream(1) as AckStream;
+                        if (ack.RasterTileSync.length > 0) {
+                            if (ack.RasterTileSync[0].endSync) {
+                                break;
+                            }
+                        }
+                    }
+                    clearInterval(monitor.id);
+                    if (monitor.data.cpu.length === 0) {
+                        await AppendTxt(usageFile_tile, await Usage(cartaBackend.pid));
+                    } else {
+                        await AppendTxt(usageFile_tile, monitor.data);
+                    }
+
+                    await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                }
+                await Wait(execTimeout);
+            }, readFileTimeout + execTimeout);
+        });
+
+    });
+
+    afterAll(async done => {
+        await Connection.close();
+        cartaBackend.kill();
+        cartaBackend.on("close", () => done());
+    }, execTimeout);
+});

--- a/src/action/ExecThreads_Animators.test.ts
+++ b/src/action/ExecThreads_Animators.test.ts
@@ -1,0 +1,193 @@
+import { CARTA } from "carta-protobuf";
+
+import Long from "long";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_03200_z00100.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let fileopenTimeout: number = config.timeout.readLargeImage;
+let animatorTimeout: number = config.timeout.readLargeImage;
+let animatorFlame: number = config.repeat.animation;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    startAnimation: CARTA.IStartAnimation;
+    stopAnimation: CARTA.IStopAnimation;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    startAnimation: {
+        fileId: 0,
+        startFrame: { channel: 1, stokes: 0 },
+        firstFrame: { channel: 0, stokes: 0 },
+        lastFrame: { channel: animatorFlame, stokes: 0 },
+        deltaFrame: { channel: 1, stokes: 0 },
+        requiredTiles: {
+            fileId: 0,
+            tiles: [
+                50343939, 50343938, 50339843, 50339842, 50348035,
+                50343940, 50348034, 50339844, 50343937, 50335747,
+                50339841, 50335746, 50348036, 50348033, 50335748,
+                50335745, 50352131, 50343941, 50352130, 50339845,
+                50343936, 50331651, 50339840, 50331650, 50352132,
+                50348037, 50352129, 50335749, 50348032, 50331652,
+                50335744, 50331649, 50352133, 50356227, 50343942,
+                50356226, 50339846, 50352128, 50331653, 50356228,
+                50348038, 50331648, 50356225, 50335750, 50356229,
+                50352134, 50356224, 50331654, 50356230
+            ],
+            compressionType: CARTA.CompressionType.ZFP,
+            compressionQuality: 9,
+        },
+        looping: false,
+        reverse: false,
+        frameRate: 30,
+    },
+    stopAnimation: {
+        fileId: 0,
+        endFrame: { channel: animatorFlame, stokes: 0 },
+    },
+}
+let testMainThreads = [
+    2, 4, 6, 8,
+    10, 12, 14, 16,
+];
+let testOmpThreads = [
+    4, 8, 12, 16,
+    20, 24, 28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Animator action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_animator.txt";
+            let usageFile = fileNameInit + "_animator_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            describe(`Start the action: animator`, () => {
+                test(`Connection is ready`, async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                }, connectTimeout);
+
+                describe(`start the action`, () => {
+                    let ackStream: AckStream;
+                    test(`should open the file "${testFile}"`, async () => {
+                        await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                        await Connection.receiveAny(); // OpenFileAck
+                    }, fileopenTimeout);
+
+                    test(`should play animator with ${assertItem.stopAnimation.endFrame.channel} frames`, async () => {
+                        await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                        await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                        while (true) {
+                            ackStream = await Connection.stream(1) as AckStream;
+                            if (ackStream.RasterTileSync.length > 0) {
+                                if (ackStream.RasterTileSync[0].endSync) {
+                                    break;
+                                }
+                            }
+                        }
+
+                        await Connection.send(CARTA.StartAnimation, assertItem.startAnimation);
+                        await Connection.send(CARTA.AddRequiredTiles, assertItem.startAnimation.requiredTiles);
+                        await Connection.receive(CARTA.StartAnimationAck);
+
+                        let monitor;
+                        for (let channel: number = 1; channel <= assertItem.stopAnimation.endFrame.channel; channel++) {
+                            monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            while (true) {
+                                ackStream = await Connection.stream(1) as AckStream;
+                                if (ackStream.RasterTileSync.length > 0) {
+                                    if (ackStream.RasterTileSync[0].endSync) {
+                                        break;
+                                    }
+                                }
+                            };
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile, monitor.data);
+                            }
+                            await Connection.send(CARTA.AnimationFlowControl,
+                                {
+                                    fileId: 0,
+                                    animationId: 1,
+                                    receivedFrame: {
+                                        channel: channel,
+                                        stokes: 0
+                                    },
+                                    timestamp: Long.fromNumber(Date.now()),
+                                }
+                            );
+                        }
+                        await Connection.send(CARTA.StopAnimation, assertItem.stopAnimation);
+
+                        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                    }, animatorTimeout * animatorFlame);
+                });
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_Contour.test.ts
+++ b/src/action/ExecThreads_Contour.test.ts
@@ -1,0 +1,166 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_06400_z00001.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let readfileTimeout: number = config.timeout.readLargeImage;
+let contourTimeout: number = config.timeout.contourLargeImage;
+let contourRepeat: number = config.repeat.contour;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setContour: CARTA.ISetContourParameters;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    setContour: {
+        fileId: 0,
+        referenceFileId: 0,
+        levels: [
+            // 1.27, 2.0, 2.2, 3.0,
+            3.75, 4.0, 4.99, 5.2,
+            6.23, 6.6, 7.47, 7.8,
+            8.71, 9.0, 9.95, 10.2,
+        ],
+        smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+        smoothingFactor: 4,
+        decimationFactor: 4,
+        compressionLevel: 0,
+        contourChunkSize: 100000,
+    },
+}
+let testMainThreads = [
+    2, 4,
+    6, 8,
+    10, 12,
+    14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    12, 16,
+    20, 24,
+    28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        describe(`Contour action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_contour.txt";
+            let usageFile = fileNameInit + "_contour_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+            for (let idx: number = 0; idx < contourRepeat; idx++) {
+                let port = config.port + idx;
+                let testServerUrl: string = `${config.localHost}:${port}`
+                describe(`Repeat ${idx + 1}`, () => {
+                    test(`CARTA is ready`, async () => {
+                        cartaBackend = await Socket.CartaBackend(
+                            logFile,
+                            port,
+                            mainThread,
+                            ompThread,
+                        );
+                        await Wait(config.wait.exec);
+                    }, execTimeout + config.wait.exec);
+
+                    describe(`Start the action: contour`, () => {
+                        test(`Connection is ready`, async () => {
+                            Connection = new Client(testServerUrl);
+                            await Connection.open();
+                            await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                            await Connection.receive(CARTA.RegisterViewerAck);
+                        }, connectTimeout);
+
+                        describe(`open the file "${testFile}"`, () => {
+                            let ack: AckStream;
+                            beforeAll(async () => {
+                                await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                                ack = await Connection.stream(2) as AckStream; // OpenFileAck | RegionHistogramData
+                                await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                                await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                                while ((await Connection.receiveAny() as CARTA.RasterTileSync).endSync) { }
+                            }, readfileTimeout);
+
+                            test(`should return contour data`, async () => {
+                                let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                                await Connection.send(CARTA.SetContourParameters, {
+                                    imageBounds: {
+                                        xMin: 0, xMax: <CARTA.OpenFile>(ack.Responce[0]).fileInfoExtended.width,
+                                        yMin: 0, yMax: <CARTA.OpenFile>(ack.Responce[0]).fileInfoExtended.height,
+                                    },
+                                    ...assertItem.setContour,
+                                });
+
+                                let count: number = 0;
+                                while (count < assertItem.setContour.levels.length) {
+                                    await Connection.receive(CARTA.ContourImageData)
+                                        .then((contourImageData: CARTA.ContourImageData) => {
+                                            if (contourImageData.progress == 1) count++;
+                                        });
+                                }
+
+                                clearInterval(monitor.id);
+                                if (monitor.data.cpu.length === 0) {
+                                    await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                                } else {
+                                    await AppendTxt(usageFile, monitor.data);
+                                }
+                                await Connection.send(CARTA.SetContourParameters, {
+                                    fileId: 0,
+                                    referenceFileId: 0,
+                                }); // Clear contour
+                            }, contourTimeout);
+
+                        });
+
+                        afterAll(async done => {
+                            await Connection.close();
+                            cartaBackend.kill();
+                            cartaBackend.on("close", () => done());
+                        }, execTimeout);
+                    });
+                });
+            }
+        });
+    });
+});

--- a/src/action/ExecThreads_CubeHistogram.test.ts
+++ b/src/action/ExecThreads_CubeHistogram.test.ts
@@ -90,7 +90,7 @@ testMainThreads.map(mainThread => {
                     ompThread,
                 );
                 await Wait(config.wait.exec);
-            }, execTimeout);
+            }, execTimeout + config.wait.exec);
 
             describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
                 beforeAll(async () => {

--- a/src/action/ExecThreads_CubeHistogram.test.ts
+++ b/src/action/ExecThreads_CubeHistogram.test.ts
@@ -1,0 +1,135 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_01600_z00100.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let fileopenTimeout: number = config.timeout.readLargeImage;
+let cubeHistogramTimeout: number = config.timeout.cubeHistogramLarge;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setHistogramRequirements: CARTA.ISetHistogramRequirements;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq:
+    {
+        tiles: [0],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+    setHistogramRequirements: {
+        fileId: 0,
+        regionId: -2,
+        histograms: [
+            { channel: -2, numBins: -1 },
+        ],
+    },
+}
+let testMainThreads = [
+    2, 4,
+    6, 8,
+    10, 12,
+    14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    12, 16,
+    20, 24,
+    28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Cube histogram action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_cubeHistogram.txt";
+            let usageFile = fileNameInit + "_cubeHistogram_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout);
+
+            describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+                beforeAll(async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                }, connectTimeout);
+
+                describe(`start the action`, () => {
+                    for (let index = 0; index < config.repeat.cubeHistogram; index++) {
+                        test(`should open the file "${testFile}"`, async () => {
+                            await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                            await Connection.stream(2) // OpenFileAck | RegionHistogramData
+                        }, fileopenTimeout);
+
+                        test(`should get cube histogram`, async () => {
+                            let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
+                            while ((await Connection.stream(1) as AckStream).RegionHistogramData[0].progress < 1) { }
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile, monitor.data);
+                            }
+
+                            await Wait(config.wait.histogram);
+                            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                        }, cubeHistogramTimeout + config.wait.histogram);
+                    }
+                });
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_LoadImage.test.ts
+++ b/src/action/ExecThreads_LoadImage.test.ts
@@ -1,0 +1,145 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_12800_z00001.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let listTimeout: number = config.timeout.listFile;
+let readFileTimeout: number = config.timeout.readFile;
+let imageReload: number = config.repeat.image;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq:
+    {
+        tiles: [
+            33558529, 33562625, 33558528, 33558530,
+            33554433, 33562624, 33562626, 33554432,
+            33554434, 33566721, 33558531, 33566720,
+            33566722, 33562627, 33554435, 33566723
+        ],
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+    },
+}
+let testMainThreads = [
+    2, 4, 6, 8,
+    10, 12, 14, 16,
+];
+let testOmpThreads = [
+    4, 8, 12, 16,
+    20, 24, 28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Load Image action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string =  testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_loadImage.txt";
+            let usageFile_openFile = fileNameInit + "_openfile_usage.txt";
+            let usageFile_tile = fileNameInit + "_tile_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile_openFile);
+                await EmptyTxt(usageFile_tile);
+            });
+
+            beforeAll(async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            describe(`CARTA is ready`, () => {
+                beforeAll(async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                    await Connection.send(CARTA.FileListRequest, assertItem.filelist);
+                    await Connection.receive(CARTA.FileListResponse);
+                }, listTimeout);
+
+                describe(`open the file "${testFile}"`, () => {
+                    test(`${imageReload} images data should return`, async () => {
+                        for (let index: number = 0; index < imageReload; index++) {
+                            let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                            await Connection.receiveAny(); // OpenFileAck
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile_openFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile_openFile, monitor.data);
+                            }
+
+                            monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+                            await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                            let ack: AckStream;
+                            while (true) {
+                                ack = await Connection.stream(1) as AckStream;
+                                if (ack.RasterTileSync.length > 0) {
+                                    if (ack.RasterTileSync[0].endSync) {
+                                        break;
+                                    }
+                                }
+                            }
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile_tile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile_tile, monitor.data);
+                            }
+                            await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                        }
+                    }, readFileTimeout * imageReload);
+                });
+
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_Resume.test.ts
+++ b/src/action/ExecThreads_Resume.test.ts
@@ -1,0 +1,142 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_12800_z00001.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let resumeTimeout: number = config.timeout.resumeLargeImage;
+let resumeRepeat: number = config.repeat.resumeSession;
+let resumeWait: number = config.wait.resume;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    stopAnomator: CARTA.IStopAnimation;
+    setImageChannel: CARTA.ISetImageChannels;
+    resumeSession: CARTA.IResumeSession;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 30,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    stopAnomator: {
+        fileId: 0,
+        endFrame: { channel: 0, stokes: 0 },
+    },
+    setImageChannel: {
+        fileId: 0,
+        channel: 0,
+        stokes: 0,
+        requiredTiles: {
+            tiles: [0],
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+    },
+    resumeSession: {
+        images: [
+            {
+                file: testFile,
+                directory: testSubdirectory,
+                hdu: "",
+                fileId: 0,
+                renderMode: CARTA.RenderMode.RASTER,
+                channel: 0,
+                stokes: 0,
+                regions: {
+                    "region0": {
+                        regionType: CARTA.RegionType.POINT,
+                        controlPoints: [{ x: 1.0, y: 1.0, },],
+                        rotation: 0,
+                    },
+                },
+                contourSettings: {
+                    fileId: 0,
+                    referenceFileId: 0,
+                    imageBounds: { xMin: 0, xMax: 800, yMin: 0, yMax: 800 },
+                    levels: [
+                        1.27, 2.0, 2.51, 3.0,
+                        3.75, 4.0, 4.99, 5.2,
+                        6.23, 6.6, 7.47, 7.8,
+                        8.71, 9.0, 9.95, 10.2,
+                    ],
+                    smoothingMode: CARTA.SmoothingMode.GaussianBlur,
+                    smoothingFactor: 4,
+                    decimationFactor: 4,
+                    compressionLevel: 8,
+                    contourChunkSize: 100000,
+                },
+            },
+        ],
+    },
+}
+let testMainThreads = [
+    2, 4,
+    6, 8,
+    10, 12,
+    14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    12, 16,
+    20, 24,
+    28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Resume action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_resume.txt";
+            let usageFile = fileNameInit + "_resume_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            for (let idx = 0; idx < resumeRepeat; idx++) {
+                test(`should resume session and reopen image "${testFile}"`, async () => {
+                    let Connection: Client = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                    await Connection.send(CARTA.StopAnimation, assertItem.stopAnomator);
+                    await Connection.send(CARTA.SetImageChannels, assertItem.setImageChannel);
+                    let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                    await Connection.send(CARTA.ResumeSession, assertItem.resumeSession);
+                    while ((await Connection.receiveAny() as CARTA.ResumeSessionAck).success) { };
+                    clearInterval(monitor.id);
+                    if (monitor.data.cpu.length === 0) {
+                        await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                    } else {
+                        await AppendTxt(usageFile, monitor.data);
+                    }
+
+                    await Wait(resumeWait);
+                    Connection.close();
+                }, resumeTimeout + resumeWait);
+            }
+
+            afterAll(done => {
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_Z-ProfileCursor.test.ts
+++ b/src/action/ExecThreads_Z-ProfileCursor.test.ts
@@ -100,7 +100,7 @@ testMainThreads.map(mainThread => {
 
                     test(`should get z-profile`, async () => {
                         const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                        await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                        // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
                         for (let idx = 0; idx < cursorRepeat; idx++) {
                             await Connection.send(CARTA.SetCursor, {
                                 ...assertItem.setCursor,

--- a/src/action/ExecThreads_Z-ProfileCursor.test.ts
+++ b/src/action/ExecThreads_Z-ProfileCursor.test.ts
@@ -1,0 +1,137 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_12800_z00100.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let fileopenTimeout: number = config.timeout.readLargeImage;
+let cursorTimeout: number = config.timeout.mouseEvent;
+let cursorRepeat: number = config.repeat.cursor;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 500.0, y: 500.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    setSpectralRequirements: {
+        fileId: 0,
+        regionId: 0,
+        spectralProfiles: [{ coordinate: "z", statsTypes: [CARTA.StatsType.Sum] }],
+    },
+}
+let testMainThreads = [
+    2, 4,
+    6, 8,
+    10, 12,
+    14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    12, 16,
+    20, 24,
+    28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Z profile cursor action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_ZProfileCursor.txt";
+            let usageFile = fileNameInit + "_ZProfileCursor_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+                beforeAll(async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                }, connectTimeout);
+
+                describe(`start the action`, () => {
+                    let ack: AckStream;
+                    test(`should open the file "${testFile}"`, async () => {
+                        await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                        ack = await Connection.stream(2) as AckStream; // OpenFileAck | RegionHistogramData
+                    }, fileopenTimeout);
+
+                    test(`should get z-profile`, async () => {
+                        const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
+                        await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                        for (let idx = 0; idx < cursorRepeat; idx++) {
+                            await Connection.send(CARTA.SetCursor, {
+                                ...assertItem.setCursor,
+                                point: {
+                                    x: Math.floor(width * (.3 + .4 * Math.random())),
+                                    y: Math.floor(width * (.3 + .4 * Math.random())),
+                                },
+                            });
+                            await Connection.receiveAny();
+                            let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                            while ((await Connection.receive(CARTA.SpectralProfileData) as CARTA.SpectralProfileData).progress < 1) { }
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile, monitor.data);
+                            }
+                            await Wait(config.wait.cursor);
+                        }
+
+                        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                    }, (cursorTimeout + config.wait.cursor) * cursorRepeat);
+                });
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_Z-ProfileRegion.test.ts
+++ b/src/action/ExecThreads_Z-ProfileRegion.test.ts
@@ -1,0 +1,155 @@
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_03200_z00100.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let fileopenTimeout: number = config.timeout.readLargeImage;
+let cursorTimeout: number = config.timeout.regionLargeImage;
+let cursorRepeat: number = config.repeat.region;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements;
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "0",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setRegion: {
+        fileId: 0,
+        regionId: 1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 50, y: 50 }, { x: 0, y: 0 }],
+            rotation: 0.0,
+        },
+    },
+    setSpectralRequirements: {
+        fileId: 0,
+        regionId: 1,
+        spectralProfiles: [{ coordinate: "z", statsTypes: [CARTA.StatsType.Sum] }],
+    },
+}
+let testMainThreads = [
+    2, 4,
+    6, 8,
+    10, 12,
+    14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    12, 16,
+    20, 24,
+    28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Z profile region action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_ZProfileRegion.txt";
+            let usageFile = fileNameInit + "_ZProfileRegion_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+                beforeAll(async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                }, connectTimeout);
+
+                describe(`start the action`, () => {
+                    let ack: AckStream;
+                    test(`should open the file "${testFile}"`, async () => {
+                        await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                        ack = await Connection.stream(2) as AckStream; // OpenFileAck | RegionHistogramData
+                    }, fileopenTimeout);
+
+                    test(`should get z-profile`, async () => {
+                        await Connection.send(CARTA.SetRegion, {
+                            regionId: -1,
+                            ...assertItem.setRegion,
+                        });
+                        await Connection.receiveAny();
+                        await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                        await Connection.receiveAny();
+
+                        for (let idx = 0; idx < cursorRepeat; idx++) {
+                            let Dx = Math.floor((ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width * (.4 + .2 * Math.random()));
+                            let Dy = Math.floor((ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.height * (.4 + .2 * Math.random()));
+                            await Connection.send(CARTA.SetRegion, {
+                                ...assertItem.setRegion,
+                                regionInfo: {
+                                    ...assertItem.setRegion.regionInfo,
+                                    controlPoints: [
+                                        {
+                                            x: Dx - assertItem.setRegion.regionInfo.controlPoints[0].x * .5,
+                                            y: Dy - assertItem.setRegion.regionInfo.controlPoints[0].y * .5,
+                                        },
+                                        {
+                                            x: Dx + assertItem.setRegion.regionInfo.controlPoints[0].x * .5,
+                                            y: Dy + assertItem.setRegion.regionInfo.controlPoints[0].y * .5,
+                                        },
+                                    ],
+                                },
+                            });
+                            await Connection.receiveAny();
+                            let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                            while ((await Connection.receive(CARTA.SpectralProfileData) as CARTA.SpectralProfileData).progress < 1) { }
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile, monitor.data);
+                            }
+                            await Wait(config.wait.cursor);
+                        }
+
+                        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+                    }, (cursorTimeout + config.wait.cursor) * cursorRepeat);
+                });
+
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_ZoomIn.test.ts
+++ b/src/action/ExecThreads_ZoomIn.test.ts
@@ -1,0 +1,179 @@
+
+import { CARTA } from "carta-protobuf";
+
+import { Client, AckStream, Usage, AppendTxt, EmptyTxt, Wait, Monitor } from "./CLIENT";
+import * as Socket from "./SocketOperation";
+import config from "./config.json";
+let testFile: string = "cube_A/cube_A_12800_z00001.fits"
+let testSubdirectory: string = config.path.performance;
+let execTimeout: number = config.timeout.execute;
+let connectTimeout: number = config.timeout.connection;
+let readTimeout: number = config.timeout.readLargeImage;
+let zoomTimeout: number = config.timeout.zoom;
+let zoomRepeat: number = config.repeat.zoom;
+let monitorPeriod: number = config.wait.monitor;
+interface AssertItem {
+    register: CARTA.IRegisterViewer;
+    filelist: CARTA.IFileListRequest;
+    fileOpen: CARTA.IOpenFile;
+    setCursor: CARTA.ISetCursor;
+    addTilesReq: CARTA.IAddRequiredTiles[];
+}
+let assertItem: AssertItem = {
+    register: {
+        sessionId: 0,
+        apiKey: "",
+        clientFeatureFlags: 5,
+    },
+    filelist: { directory: testSubdirectory },
+    fileOpen: {
+        file: testFile,
+        directory: testSubdirectory,
+        hdu: "",
+        fileId: 0,
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+    setCursor: {
+        fileId: 0,
+        point: { x: 1.0, y: 1.0 },
+        spatialRequirements: {
+            fileId: 0,
+            regionId: 0,
+            spatialProfiles: []
+        },
+    },
+    addTilesReq: [
+        {
+            tiles: [16777216, 16781312, 16777217, 16781313],
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+        {
+            tiles: [
+                50343939, 50343938, 50339843, 50339842, 50348035,
+                50343940, 50348034, 50339844, 50343937, 50335747,
+                50339841, 50335746, 50348036, 50348033, 50335748,
+                50335745, 50352131, 50343941, 50352130, 50339845,
+                50343936, 50331651, 50339840, 50331650, 50352132,
+                50348037, 50352129, 50335749, 50348032, 50331652,
+                50335744, 50331649, 50352133, 50356227, 50343942,
+                50356226, 50339846, 50352128, 50331653, 50356228,
+                50348038, 50331648, 50356225, 50335750, 50356229,
+                50352134, 50356224, 50331654, 50356230
+            ],
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+        },
+    ],
+}
+let testMainThreads = [
+    2, 4,
+    // 6, 8,
+    // 10, 12,
+    // 14, 16,
+];
+let testOmpThreads = [
+    4, 8,
+    // 12, 16,
+    // 20, 24,
+    // 28, 32,
+];
+testMainThreads.map(mainThread => {
+    testOmpThreads.map(ompThread => {
+        let testServerUrl: string = `${config.localHost}:${config.port}`;
+        describe(`Zoom In Iamge action: thread=${mainThread}, omp thread=${ompThread}`, () => {
+            let Connection: Client;
+            let cartaBackend: any;
+            let fileNameInit: string = testFile.substr(testFile.search('/') + 1).replace('.', '_') + "_" + mainThread + "_" + ompThread;
+            let logFile = fileNameInit + "_ZoomIn.txt";
+            let usageFile = fileNameInit + "_ZoomIn_usage.txt";
+            test(`Empty the record files`, async () => {
+                await EmptyTxt(logFile);
+                await EmptyTxt(usageFile);
+            });
+
+            test(`CARTA is ready`, async () => {
+                cartaBackend = await Socket.CartaBackend(
+                    logFile,
+                    config.port,
+                    mainThread,
+                    ompThread,
+                );
+                await Wait(config.wait.exec);
+            }, execTimeout + config.wait.exec);
+
+            describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
+                beforeAll(async () => {
+                    Connection = new Client(testServerUrl);
+                    await Connection.open();
+                    await Connection.send(CARTA.RegisterViewer, assertItem.register);
+                    await Connection.receive(CARTA.RegisterViewerAck);
+                }, connectTimeout);
+
+                describe(`start the action`, () => {
+                    test(`should open the file "${testFile}"`, async () => {
+                        await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
+                        await Connection.send(CARTA.SetCursor, assertItem.setCursor);
+                        await Connection.stream(2); // OpenFileAck | RegionHistogramData
+                        await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
+                        let ack: AckStream;
+                        while (true) {
+                            ack = await Connection.stream(1) as AckStream;
+                            if (ack.RasterTileSync.length > 0) {
+                                if (ack.RasterTileSync[0].endSync) {
+                                    break;
+                                }
+                            }
+                        }
+                    }, readTimeout);;
+
+                    for (let idx: number = 0; idx < zoomRepeat; idx++) {
+                        test(`image should zoom in`, async () => {
+                            let monitor = Monitor(cartaBackend.pid, monitorPeriod);
+                            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+                            let ack: AckStream;
+                            while (true) {
+                                ack = await Connection.stream(1) as AckStream;
+                                if (ack.RasterTileSync.length > 0) {
+                                    if (ack.RasterTileSync[0].endSync) {
+                                        break;
+                                    }
+                                }
+                            }
+                            clearInterval(monitor.id);
+                            if (monitor.data.cpu.length === 0) {
+                                await AppendTxt(usageFile, await Usage(cartaBackend.pid));
+                            } else {
+                                await AppendTxt(usageFile, monitor.data);
+                            }
+                            await Wait(config.wait.zoom);
+                        }, zoomTimeout + config.wait.zoom);
+
+                        test(`image should zoom out`, async () => {
+                            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
+                            let ack: AckStream;
+                            while (true) {
+                                ack = await Connection.stream(1) as AckStream;
+                                if (ack.RasterTileSync.length > 0) {
+                                    if (ack.RasterTileSync[0].endSync) {
+                                        break;
+                                    }
+                                }
+                            }
+                            await new Promise(resolve => setTimeout(resolve, config.wait.zoom));
+                        }, zoomTimeout);
+                    }
+                });
+
+            });
+
+            afterAll(async done => {
+                await Connection.close();
+                cartaBackend.kill();
+                cartaBackend.on("close", () => done());
+            }, execTimeout);
+        });
+    });
+});

--- a/src/action/ExecThreads_ZoomIn.test.ts
+++ b/src/action/ExecThreads_ZoomIn.test.ts
@@ -70,15 +70,15 @@ let assertItem: AssertItem = {
 }
 let testMainThreads = [
     2, 4,
-    // 6, 8,
-    // 10, 12,
-    // 14, 16,
+    6, 8,
+    10, 12,
+    14, 16,
 ];
 let testOmpThreads = [
     4, 8,
-    // 12, 16,
-    // 20, 24,
-    // 28, 32,
+    12, 16,
+    20, 24,
+    28, 32,
 ];
 testMainThreads.map(mainThread => {
     testOmpThreads.map(ompThread => {

--- a/src/action/Exec_CubeHistogramImages.test.ts
+++ b/src/action/Exec_CubeHistogramImages.test.ts
@@ -100,7 +100,7 @@ testFiles.map(file => {
                 config.port,
             );
             await Wait(config.wait.exec);
-        }, execTimeout);
+        }, execTimeout + config.wait.exec);
 
         describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
             beforeAll(async () => {

--- a/src/action/Exec_Z-ProfileCursor.test.ts
+++ b/src/action/Exec_Z-ProfileCursor.test.ts
@@ -39,7 +39,7 @@ let assertItem: AssertItem = {
         spatialRequirements: {
             fileId: 0,
             regionId: 0,
-            spatialProfiles: []
+            spatialProfiles: [],
         },
     },
     setSpectralRequirements: {
@@ -84,8 +84,10 @@ describe("Z profile cursor action: ", () => {
 
             test(`should get z-profile`, async () => {
                 const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                await Connection.receiveAny();
                 for (let idx = 0; idx < cursorRepeat; idx++) {
+                    let monitor = Monitor(cartaBackend.pid, monitorPeriod);
                     await Connection.send(CARTA.SetCursor, {
                         ...assertItem.setCursor,
                         point: {
@@ -93,10 +95,14 @@ describe("Z profile cursor action: ", () => {
                             y: Math.floor(width * (.3 + .4 * Math.random())),
                         },
                     });
-                    await Connection.receiveAny();
-                    let monitor = Monitor(cartaBackend.pid, monitorPeriod);
-                    await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
-                    while ((await Connection.receive(CARTA.SpectralProfileData) as CARTA.SpectralProfileData).progress < 1) { }
+                    ack = await Connection.stream(1) as AckStream;
+                    while (ack.SpectralProfileData.length) {
+                        if (ack.SpectralProfileData[0].progress == 1) {
+                            break;
+                        } else {
+                            ack = await Connection.stream(1) as AckStream;
+                        }
+                    }
                     clearInterval(monitor.id);
                     if (monitor.data.cpu.length === 0) {
                         await AppendTxt(usageFile, await Usage(cartaBackend.pid));

--- a/src/action/Exec_Z-ProfileCursor.test.ts
+++ b/src/action/Exec_Z-ProfileCursor.test.ts
@@ -84,7 +84,7 @@ describe("Z profile cursor action: ", () => {
 
             test(`should get z-profile`, async () => {
                 const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
                 for (let idx = 0; idx < cursorRepeat; idx++) {
                     await Connection.send(CARTA.SetCursor, {
                         ...assertItem.setCursor,

--- a/src/action/Exec_Z-ProfileCursorImages.test.ts
+++ b/src/action/Exec_Z-ProfileCursorImages.test.ts
@@ -36,7 +36,7 @@ let assertItem: AssertItem = {
         spatialRequirements: {
             fileId: 0,
             regionId: 0,
-            spatialProfiles: []
+            spatialProfiles: [],
         },
     },
     setSpectralRequirements: {
@@ -116,8 +116,10 @@ testFiles.map(file => {
 
                 test(`should get z-profile`, async () => {
                     const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                    // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    await Connection.receiveAny();
                     for (let idx = 0; idx < cursorRepeat; idx++) {
+                        let monitor = Monitor(cartaBackend.pid, monitorPeriod);
                         await Connection.send(CARTA.SetCursor, {
                             ...assertItem.setCursor,
                             point: {
@@ -125,10 +127,14 @@ testFiles.map(file => {
                                 y: Math.floor(width * (.3 + .4 * Math.random())),
                             },
                         });
-                        await Connection.receiveAny();
-                        let monitor = Monitor(cartaBackend.pid, monitorPeriod);
-                        await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
-                        while ((await Connection.receive(CARTA.SpectralProfileData) as CARTA.SpectralProfileData).progress < 1) { }
+                        ack = await Connection.stream(1) as AckStream;
+                        while (ack.SpectralProfileData.length) {
+                            if (ack.SpectralProfileData[0].progress == 1) {
+                                break;
+                            } else {
+                                ack = await Connection.stream(1) as AckStream;
+                            }
+                        }
                         clearInterval(monitor.id);
                         if (monitor.data.cpu.length === 0) {
                             await AppendTxt(usageFile, await Usage(cartaBackend.pid));

--- a/src/action/Exec_Z-ProfileCursorImages.test.ts
+++ b/src/action/Exec_Z-ProfileCursorImages.test.ts
@@ -116,7 +116,7 @@ testFiles.map(file => {
 
                 test(`should get z-profile`, async () => {
                     const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                    await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
                     for (let idx = 0; idx < cursorRepeat; idx++) {
                         await Connection.send(CARTA.SetCursor, {
                             ...assertItem.setCursor,

--- a/src/action/SocketOperation.ts
+++ b/src/action/SocketOperation.ts
@@ -1,114 +1,12 @@
 import * as child_process from "child_process";
 
-import { CARTA } from "carta-protobuf";
-
-import * as Utility from "../UtilityFunction";
-
 import config from "./config.json";
-// const procfs = require("procfs-stats");
-const nodeusage = require("usage");
 const fs = require("fs");
 
 let commandPath: string = "/usr/local/bin/pagecache-management.sh";
 let backendPath: string = "/home/hengtai/carta-backend/build/carta_backend";
 let basePath: string = "/almalustre/carta/images";
-/// Log result
-export interface Report {
-    file: string;
-    timeEpoch: TimeEpoch[];
-}
-export interface TimeEpoch {
-    time: number;
-    thread: number;
-    CPUusage: number;
-    RAM: number;
-    fileName: string;
-    Disk: number;
-}
-export async function
-    Outcome(
-        timeEpoch: { time: number, thread: number, CPUusage: number, RAM: number }[],
-) {
-    console.log(`Backend testing outcome:\n${timeEpoch
-        .map(e => `${e.time.toPrecision(5)}ms with CPU usage = ${e.CPUusage.toPrecision(5)}% & RAM = ${e.RAM}kB as thread# = ${e.thread}`).join(` \n`)}`);
-}
-export async function
-    OutcomeWithFile(
-        timeEpoch: { time: number, thread: number, CPUusage: number, RAM: number, fileName: string }[],
-) {
-    console.log(`Backend testing outcome:\n${timeEpoch
-        .map(e => `${e.time.toPrecision(5)}ms with CPU usage = ${e.CPUusage.toPrecision(5)}% & RAM = ${e.RAM}kB as file: ${e.fileName}`).join(` \n`)}`);
-}
-export async function
-    OutcomeWithDiskIO(
-        timeEpoch: { time: number, thread: number, CPUusage: number, RAM: number, fileName: string, Disk: number }[],
-) {
-    console.log(`Backend testing outcome:\n${timeEpoch
-        .map(e => `${e.time.toPrecision(5)}ms with CPU usage = ${e.CPUusage.toPrecision(5)}% & RAM = ${e.RAM / 1024}kB & Disk read = ${(e.Disk / 1024).toFixed(0)}kB as file: ${e.fileName}`).join(` \n`)}`);
-}
-export async function
-    Report(
-        report: Report,
-) {
-    console.log(`Backend testing outcome on ${report.file}:\n${report.timeEpoch
-        .map(e => `${e.time.toPrecision(5)}ms with CPU usage = ${e.CPUusage.toPrecision(5)}% & RAM = ${e.RAM}kB as thread# = ${e.thread}`).join(` \n`)}`);
-}
-/// Record label to file
-export async function
-    WriteLebelTo(
-        reportFileName: string,
-) {
-    fs.appendFileSync(reportFileName,
-        `ImageFile\t#ThreadSet\tTimeElapsed\tCPU\tRAM\tDisk\t#ThreadReal\n`
-    );
-}
-/// Record result to file
-export async function
-    WriteReportTo(
-        reportFileName: string,
-        pid: number,
-        imageFile: string,
-        threadNumberSet: number,
-        timeElapsed: number[],
-        cpuCount: { user: number, total: number } = { user: 0, total: 0 },
-) {
-    let diskR: number = 0;
-    let usedThreadNumber: number = 0;
-    if (procfs.works) {
-        let ps = procfs(pid);
-        await new Promise(resolve => {
-            ps.io((err, io) => {
-                diskR = io.read_bytes;
-                resolve();
-            });
-        });
-        await new Promise(resolve => {
-            ps.threads((err, task) => {
-                usedThreadNumber = task.length;
-                resolve();
-            });
-        });
-    }
-    let cpuUsage = cpuCount.total ? (100 * cpuCount.user / cpuCount.total).toFixed(4) : 0;
-    await new Promise(resolve => {
-        nodeusage.lookup(
-            pid,
-            (err, info) => {
-                fs.appendFileSync(reportFileName,
-                    `${imageFile.split("/")[1].slice(7)}\t` +
-                    `${threadNumberSet.toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false })}\t` +
-                    `${(timeElapsed.reduce((a, b) => a + b) / timeElapsed.length).toFixed(4)}\t` +
-                    `${cpuUsage ? cpuUsage : info.cpu.toFixed(4)}\t` +
-                    `${info.memory}\t` +
-                    `${diskR}\t` +
-                    `${usedThreadNumber.toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false })}\t` +
-                    "\n"
-                );
-                resolve();
-            }
-        );
-    });
-}
+
 /// Create a new carta_backend service
 export async function
     CartaBackend(
@@ -174,22 +72,4 @@ export async function
         }
     );
     return psrecord;
-}
-/// Create a new client connection
-export async function
-    SocketClient(
-        serverURL: string,
-        port: number,
-        reconnectWait: number,
-) {
-    let Connection = await new WebSocket(`${serverURL}:${port}`);
-
-    while (Connection.readyState !== WebSocket.OPEN) {
-        await Connection.close();
-        Connection = await new WebSocket(`${serverURL}:${port}`);
-        await new Promise(time => setTimeout(time, reconnectWait));
-    }
-    Connection.binaryType = "arraybuffer";
-
-    return Connection;
 }

--- a/src/action/SocketOperation.ts
+++ b/src/action/SocketOperation.ts
@@ -128,7 +128,7 @@ export async function
                 `port=${port}`,
                 `threads=${threadNumber}`,
                 `omp_threads=${ompThreadNumber}`,
-                `verbose=true`,
+                `perflog=true`,
             ],
             {
                 timeout,

--- a/src/action/Z-ProfileCursor.test.ts
+++ b/src/action/Z-ProfileCursor.test.ts
@@ -73,7 +73,7 @@ describe("Z profile cursor: ", () => {
 
                 test(`should get z-profile`, async () => {
                     const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                    await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
                     for (let idx = 0; idx < cursorRepeat; idx++) {
                         await Connection.send(CARTA.SetCursor, {
                             ...assertItem.setCursor,

--- a/src/action/Z-ProfileCursor.test.ts
+++ b/src/action/Z-ProfileCursor.test.ts
@@ -37,7 +37,7 @@ let assertItem: AssertItem = {
         spatialRequirements: {
             fileId: 0,
             regionId: 0,
-            spatialProfiles: []
+            spatialProfiles: [],
         },
     },
     setSpectralRequirements: {
@@ -73,7 +73,8 @@ describe("Z profile cursor: ", () => {
 
                 test(`should get z-profile`, async () => {
                     const width = (ack.Responce[0] as CARTA.OpenFileAck).fileInfoExtended.width;
-                    // await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
+                    await Connection.receiveAny();
                     for (let idx = 0; idx < cursorRepeat; idx++) {
                         await Connection.send(CARTA.SetCursor, {
                             ...assertItem.setCursor,
@@ -82,10 +83,14 @@ describe("Z profile cursor: ", () => {
                                 y: Math.floor(width * (.3 + .4 * Math.random())),
                             },
                         });
-                        await Connection.receiveAny();
-                        await Connection.send(CARTA.SetSpectralRequirements, assertItem.setSpectralRequirements);
-                        while ((await Connection.receive(CARTA.SpectralProfileData) as CARTA.SpectralProfileData).progress < 1) { }
-                        await new Promise(resolve => setTimeout(resolve, config.wait.cursor));
+                        ack = await Connection.stream(1) as AckStream;
+                        while (ack.SpectralProfileData.length) {
+                            if (ack.SpectralProfileData[0].progress == 1) {
+                                break;
+                            } else {
+                                ack = await Connection.stream(1) as AckStream;
+                            }
+                        }
                     }
 
                     await Connection.send(CARTA.CloseFile, { fileId: -1 });


### PR DESCRIPTION
From #129, add functionality for recording the number of main or openmp threads.
The tests are in name of ExecThread_*.test.ts
The testing carta_backend is in the branch `/release/1.4` .