### PR TITLE
Refactor all testing by new function streamUntil

### DIFF
--- a/src/test/ANIMATOR_DATA_STREAM.test.ts
+++ b/src/test/ANIMATOR_DATA_STREAM.test.ts
@@ -9,9 +9,8 @@ let regionTimeout = config.timeout.region;
 
 interface AssertItem {
     precisionDigits: number;
-    register: CARTA.IRegisterViewer;
-    file: CARTA.IOpenFile;
-    imageDataInfo: CARTA.ISetImageView;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
     cursor: CARTA.ISetCursor;
     spatial: CARTA.ISetSpatialRequirements;
     stats: CARTA.ISetStatsRequirements;
@@ -19,26 +18,18 @@ interface AssertItem {
     imageChannels: CARTA.ISetImageChannels[];
 }
 let assertItem: AssertItem = {
-    register:
+    registerViewer:
     {
         sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
     },
-    file: {
+    openFile: {
         directory: testSubdirectory,
         file: "M17_SWex.image",
         hdu: "",
         fileId: 0,
         renderMode: CARTA.RenderMode.RASTER,
-    },
-    imageDataInfo: {
-        fileId: 0,
-        compressionQuality: 11,
-        imageBounds: { xMin: 0, xMax: 640, yMin: 0, yMax: 800 },
-        compressionType: CARTA.CompressionType.ZFP,
-        mip: 2,
-        numSubsets: 4,
     },
     precisionDigits: 4,
     cursor: {
@@ -95,24 +86,22 @@ let assertItem: AssertItem = {
     ],
 }
 
-describe("ANIMATOR_DATA_STREAM test: Testing data streaming with animator", () => {
+describe("ANIMATOR_DATA_STREAM: Testing data streaming with animator", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
-    describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.file.file}" to set region`, () => {
+    describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}" to set region`, () => {
 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            await Connection.send(CARTA.OpenFile, assertItem.file);
-            await Connection.stream(2); // OpenFileAck | RegionHistogramData
+            await Connection.openFile(assertItem.openFile);
             await Connection.send(CARTA.SetImageChannels, assertItem.imageChannels[0]);
-            await Connection.receive(CARTA.RasterTileData);
             await Connection.send(CARTA.SetCursor, assertItem.cursor);
+            await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
         });
 
         describe(`SET SPATIAL REQUIREMENTS`, () => {
@@ -138,9 +127,11 @@ describe("ANIMATOR_DATA_STREAM test: Testing data streaming with animator", () =
 
         describe("SET IMAGE CHANNELS", () => {
             let Ack: AckStream;
+            let SpatialProfileData: CARTA.SpatialProfileData;
             test(`RASTER_TILE_DATA, SPATIAL_PROFILE_DATA, REGION_HISTOGRAM_DATA & REGION_STATS_DATA should arrive within ${changeChannelTimeout} ms`, async () => {
                 await Connection.send(CARTA.SetImageChannels, assertItem.imageChannels[1]);
                 Ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+                SpatialProfileData = Ack.SpatialProfileData[0];
             }, changeChannelTimeout);
 
             test(`RASTER_TILE_DATA.channel = ${assertItem.imageChannels[1].channel}`, () => {
@@ -160,15 +151,15 @@ describe("ANIMATOR_DATA_STREAM test: Testing data streaming with animator", () =
             });
 
             test(`SPATIAL_PROFILE_DATA.channel = ${assertItem.imageChannels[1].channel}`, () => {
-                expect(Ack.SpatialProfileData[0].channel).toEqual(assertItem.imageChannels[1].channel);
+                expect(SpatialProfileData.channel).toEqual(assertItem.imageChannels[1].channel);
             });
 
             test(`SPATIAL_PROFILE_DATA.x = ${assertItem.cursor.point.x}`, () => {
-                expect(Ack.SpatialProfileData[0].x).toEqual(assertItem.cursor.point.x);
+                expect(SpatialProfileData.x).toEqual(assertItem.cursor.point.x);
             });
 
             test(`SPATIAL_PROFILE_DATA.y = ${assertItem.cursor.point.y}`, () => {
-                expect(Ack.SpatialProfileData[0].y).toEqual(assertItem.cursor.point.y);
+                expect(SpatialProfileData.y).toEqual(assertItem.cursor.point.y);
             });
         });
 

--- a/src/test/CASA_REGION_INFO.test.ts
+++ b/src/test/CASA_REGION_INFO.test.ts
@@ -11,7 +11,7 @@ let listTimeout = config.timeout.listFile;
 let readTimeout = config.timeout.readFile;
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     precisionDigits: number;
     regionListRequest: CARTA.IRegionListRequest;
@@ -20,7 +20,7 @@ interface AssertItem {
     regionFileInfoResponse: CARTA.IRegionFileInfoResponse[];
 };
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
@@ -130,17 +130,14 @@ describe("CASA_REGION_INFO: Testing CASA region list and info", () => {
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.receiveAny();
-            await Connection.receiveAny(); // OpenFileAck | RegionHistogramData
+            await Connection.openFile(assertItem.openFile);
         });
 
         describe(`Go to "${regionSubdirectory}" and send REGION_LIST_REQUEST`, () => {
@@ -158,8 +155,8 @@ describe("CASA_REGION_INFO: Testing CASA region list and info", () => {
                 expect(regionListResponse.directory).toEqual(assertItem.regionListResponse.directory);
             });
 
-            test(`REGION_LIST_RESPONSE.parent = ${assertItem.regionListResponse.parent}`, () => {
-                expect(regionListResponse.parent).toEqual(assertItem.regionListResponse.parent);
+            test(`REGION_LIST_RESPONSE.parent is /${assertItem.regionListResponse.parent}`, () => {
+                expect(RegExp(`${regionListResponse.parent}$`).test(regionListResponse.parent)).toBe(true);
             });
 
             test(`REGION_LIST_RESPONSE.subdirectories = ${JSON.stringify(assertItem.regionListResponse.subdirectories)}`, () => {

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -174,6 +174,10 @@ export class Client {
                     }
                     let data;
                     switch (cartaType) {
+                        case CARTA.ErrorData:
+                            data = CARTA.ErrorData.decode(eventData);
+                            console.warn(data.message);
+                            break;
                         case CARTA.SpatialProfileData:
                             data = CARTA.SpatialProfileData.decode(eventData);
                             data.profiles = data.profiles.map(p => processSpatialProfile(p));
@@ -220,7 +224,7 @@ export class Client {
                 let data;
                 let type = this.CartaType.get(eventNumber);
                 switch (type) {
-                    case CARTA.EntryType:
+                    case CARTA.ErrorData:
                         data = CARTA.ErrorData.decode(eventData);
                         console.warn(data.message);
                         break;
@@ -337,7 +341,7 @@ export class Client {
                     default:
                         ack.Responce.push(data);
                         break;
-                    case CARTA.EntryType:
+                    case CARTA.ErrorData:
                         ack.Responce.push(data);
                         console.warn(data);
                         break;
@@ -474,7 +478,7 @@ export class Client {
                     default:
                         ack.Responce.push(data);
                         break;
-                    case CARTA.EntryType:
+                    case CARTA.ErrorData:
                         ack.Responce.push(data);
                         console.warn(data);
                         break;

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -430,7 +430,7 @@ export class Client {
     }
     /// Receive CARTA stream async
     /// Until isDone == True
-    streamUntil(isDone?: (type, data?, ack?) => boolean) {
+    streamUntil(isDone?: (type, data?, ack?: AckStream) => boolean) {
 
         let ack: AckStream = {
             Responce: [],

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -781,3 +781,6 @@ function unshuffle(raw: Uint8Array, decimationFactor: number): Float32Array {
     }
     return new Float32Array(data);
 }
+export function Wait(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+}

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -3,6 +3,11 @@ import { CARTA } from "carta-protobuf";
 import config from "./config.json";
 const { performance } = require('perf_hooks');
 const WebSocket = require('isomorphic-ws');
+
+export interface IOpenFile {
+    OpenFileAck: CARTA.OpenFileAck;
+    RegionHistogramData: CARTA.RegionHistogramData;
+}
 export class Client {
     IcdVersion: number = 17;
     CartaType = new Map<number, any>([
@@ -619,9 +624,14 @@ export class Client {
         return await this.receive(CARTA.RegisterViewerAck) as CARTA.RegisterViewerAck;
     }
     /// Send open_file and receive its returning message
-    async openFile(file): Promise<AckStream> {
+
+    async openFile(file): Promise<IOpenFile> {
         await this.send(CARTA.OpenFile, file);
-        return await this.stream(2) as AckStream;
+        let ack = await this.stream(2) as AckStream;
+        return {
+            OpenFileAck: ack.Responce[0],
+            RegionHistogramData: ack.RegionHistogramData[0],
+        };
     }
 };
 

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -618,6 +618,11 @@ export class Client {
         await this.send(CARTA.RegisterViewer, registerViewer);
         return await this.receive(CARTA.RegisterViewerAck) as CARTA.RegisterViewerAck;
     }
+    /// Send open_file and receive its returning message
+    async openFile(file): Promise<AckStream> {
+        await this.send(CARTA.OpenFile, file);
+        return await this.stream(2) as AckStream;
+    }
 };
 
 export interface AckStream {

--- a/src/test/CLOSE_FILE_TILE.test.ts
+++ b/src/test/CLOSE_FILE_TILE.test.ts
@@ -113,7 +113,7 @@ describe("Testing CLOSE_FILE with large-size image and test CLOSE_FILE during th
         expect(BackendStatus).toBeDefined();
         expect(BackendStatus.success).toBe(true);
         expect(BackendStatus.directory).toBe(assertItem.filelist.directory);
-    });
+    }, readFileTimeout);
 
     afterAll(() => Connection.close());
 });

--- a/src/test/CONTOUR_DATA_STREAM.test.ts
+++ b/src/test/CONTOUR_DATA_STREAM.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client, AckStream } from "./CLIENT";
+import { Client } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl: string = config.serverURL;

--- a/src/test/CONTOUR_DATA_STREAM.test.ts
+++ b/src/test/CONTOUR_DATA_STREAM.test.ts
@@ -11,9 +11,9 @@ let playTimeout: number = config.timeout.playImages;
 let messageTimeout: number = config.timeout.messageEvent;
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     filelist: CARTA.IFileListRequest;
-    fileOpen: CARTA.IOpenFile;
+    openFile: CARTA.IOpenFile;
     addTilesReq: CARTA.IAddRequiredTiles;
     setCursor: CARTA.ISetCursor;
     setContour: CARTA.ISetContourParameters[];
@@ -21,13 +21,13 @@ interface AssertItem {
 };
 
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
     },
     filelist: { directory: testSubdirectory },
-    fileOpen: {
+    openFile: {
         directory: testSubdirectory,
         file: "h_m51_b_s05_drz_sci.fits",
         fileId: 0,
@@ -70,47 +70,35 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("CONTOUR_DATA_STREAM test: Testing contour data stream when there are a lot of vertices", () => {
+describe("CONTOUR_DATA_STREAM: Testing contour data stream when there are a lot of vertices", () => {
 
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${assertItem.filelist.directory}" folder`, () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            await Connection.receiveAny() // OpenFileAck
+            await Connection.openFile(assertItem.openFile);
 
             await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
             await Connection.send(CARTA.SetCursor, assertItem.setCursor);
-            // REGION_HISTOGRAM_DATA RASTER_TILE_SYNC SPATIAL_PROFILE_DATA RASTER_TILE_DATA RASTER_TILE_SYNC
-            await Connection.stream(5) as AckStream;
+            await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
         }, readTimeout);
 
         assertItem.contourImageData.map((contour, index) => {
             describe(`SET_CONTOUR_PARAMETERS${index} with SmoothingMode:"${CARTA.SmoothingMode[assertItem.setContour[index].smoothingMode]}"`, () => {
-                let contourImageData: CARTA.ContourImageData;
                 test(`should return CONTOUR_IMAGE_DATA x${assertItem.setContour[index].levels.length} with progress = ${contour.progress} in the end`, async () => {
                     await Connection.send(CARTA.SetContourParameters, assertItem.setContour[index]);
-
-                    contourImageData = await Connection.receive(CARTA.ContourImageData);
-                    let count: number = 0;
-                    if (contourImageData.progress == 1) count++;
-
-                    while (count < assertItem.setContour[index].levels.length) {
-                        contourImageData = await Connection.receive(CARTA.ContourImageData);
-                        if (contourImageData.progress == 1) count++;
-                    }
-                    expect(count).toEqual(5);
+                    await Connection.streamUntil(
+                        (type, data, ack) => ack.ContourImageData.filter(data => data.progress == contour.progress).length == 5
+                    );
 
                     await Connection.receive(CARTA.ContourImageData, messageTimeout, false);
                 }, playTimeout);
-
             });
         });
 

--- a/src/test/DS9_REGION_INFO.test.ts
+++ b/src/test/DS9_REGION_INFO.test.ts
@@ -11,7 +11,7 @@ let listTimeout = config.timeout.listFile;
 let readTimeout = config.timeout.readFile;
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     precisionDigits: number;
     regionListRequest: CARTA.IRegionListRequest;
@@ -20,7 +20,7 @@ interface AssertItem {
     regionFileInfoResponse: CARTA.IRegionFileInfoResponse[];
 };
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
@@ -134,16 +134,14 @@ describe("DS9_REGION_INFO: Testing DS9_REG region list and info", () => {
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
 
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2); // OpenFileAck | RegionHistogramData
+            await Connection.openFile(assertItem.openFile);
         });
 
         describe(`Go to "${regionSubdirectory}" and send REGION_LIST_REQUEST`, () => {
@@ -162,7 +160,7 @@ describe("DS9_REGION_INFO: Testing DS9_REG region list and info", () => {
             });
 
             test(`REGION_LIST_RESPONSE.parent = ${assertItem.regionListResponse.parent}`, () => {
-                expect(regionListResponse.parent).toEqual(assertItem.regionListResponse.parent);
+                expect(RegExp(`${regionListResponse.parent}$`).test(regionListResponse.parent)).toBe(true);
             });
 
             test(`REGION_LIST_RESPONSE.subdirectories = ${JSON.stringify(assertItem.regionListResponse.subdirectories)}`, () => {

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client } from "./CLIENT";
+import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -71,15 +71,13 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.registerViewer);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
         await Connection.send(CARTA.CloseFile, { fileId: -1 });
     }, connectTimeout);
 
     describe(`Preparation`, () => {
         test(`Open image`, async () => {
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            await Connection.openFile(assertItem.openFile);
         }, readFileTimeout);
 
         test(`Set region`, async () => {
@@ -91,29 +89,12 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
 
     let FileId: number[] = [];
     describe(`Moment generator`, () => {
-        let MomentProgress: CARTA.MomentProgress[] = [];
-        let MomentResponse: CARTA.MomentResponse;
+        let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
-            let ack;
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            // ack = await Connection.streamUntil(3000, type => type!=CARTA.MomentResponse);
-            do {
-                ack = await Connection.receiveAny();
-                switch (ack.constructor.name) {
-                    case "MomentResponse":
-                        MomentResponse = ack;
-                        break;
-                    case "MomentProgress":
-                        MomentProgress.push(ack);
-                        break;
-                    case "RegionHistogramData":
-                        FileId.push(ack.fileId);
-                        break;
-                    default:
-                        break;
-                }
-            } while (ack.constructor.name != "MomentResponse");
-            expect(MomentProgress.length).toBeGreaterThan(0);
+            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            FileId = ack.RegionHistogramData.map(data => data.fileId);
+            expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
 
         test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
@@ -121,33 +102,33 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
         });
 
         test(`Assert MomentResponse.success = true`, () => {
-            expect(MomentResponse.success).toBe(true);
+            expect(ack.MomentResponse[0].success).toBe(true);
         });
 
         test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
-            expect(MomentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            expect(ack.MomentResponse[0].openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
         });
 
         test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 expect(ack.success).toBe(true);
             });
         });
 
         test(`Assert all openFileAcks[].fileId > 0`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 expect(ack.fileId).toBeGreaterThan(0);
             });
         });
 
         test(`Assert openFileAcks[].fileInfo.name`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfo.name).toEqual(assertItem.openFile.file + ".moment." + momentName[index]);
             });
         });
 
         test(`Assert openFileAcks[].fileInfoExtended`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 const coord = assertItem.setRegion.regionInfo.controlPoints;
                 expect(ack.fileInfoExtended.height).toEqual(coord[1].y + 1);
                 expect(ack.fileInfoExtended.width).toEqual(coord[1].x + 1);
@@ -158,13 +139,13 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
         });
 
         test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 71`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfoExtended.headerEntries.length).toEqual(71);
             });
         });
 
         test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 15`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfoExtended.computedEntries.length).toEqual(15);
             });
         });
@@ -182,22 +163,10 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                     compressionType: CARTA.CompressionType.NONE,
                     compressionQuality: 0,
                 });
-                let ack;
-                do {
-                    ack = await Connection.receiveAny();
-                    switch (ack.constructor.name) {
-                        case "RasterTileSync":
-                            if (ack.endSync) {
-                                RasterTileSync.push(ack);
-                            }
-                            break;
-                        case "RasterTileData":
-                            RasterTileData.push(ack);
-                            break;
-                        default:
-                            break;
-                    }
-                } while (!(ack.constructor.name == "RasterTileSync" && ack.endSync));
+                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false).then(ack => {
+                    RasterTileSync.push(...ack.RasterTileSync.slice(-1));
+                    RasterTileData.push(...ack.RasterTileData);
+                });
             }
             RasterTileSync.map(ack => {
                 expect(ack.endSync).toBe(true);

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client } from "./CLIENT";
+import { Client,AckStream } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -71,15 +71,13 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.registerViewer);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
         await Connection.send(CARTA.CloseFile, { fileId: -1 });
     }, connectTimeout);
 
     describe(`Preparation`, () => {
         test(`Open image`, async () => {
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            await Connection.openFile(assertItem.openFile);
         }, readFileTimeout);
 
         test(`Set region`, async () => {
@@ -91,29 +89,12 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
 
     let FileId: number[] = [];
     describe(`Moment generator`, () => {
-        let MomentProgress: CARTA.MomentProgress[] = [];
-        let MomentResponse: CARTA.MomentResponse;
+        let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
-            let ack;
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            // ack = await Connection.streamUntil(3000, type => type!=CARTA.MomentResponse);
-            do {
-                ack = await Connection.receiveAny();
-                switch (ack.constructor.name) {
-                    case "MomentResponse":
-                        MomentResponse = ack;
-                        break;
-                    case "MomentProgress":
-                        MomentProgress.push(ack);
-                        break;
-                    case "RegionHistogramData":
-                        FileId.push(ack.fileId);
-                        break;
-                    default:
-                        break;
-                }
-            } while (ack.constructor.name != "MomentResponse");
-            expect(MomentProgress.length).toBeGreaterThan(0);
+            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            FileId = ack.RegionHistogramData.map(data => data.fileId);
+            expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
 
         test(`Receive ${assertItem.momentRequest.moments.length} REGION_HISTOGRAM_DATA`, () => {
@@ -121,33 +102,33 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
         });
 
         test(`Assert MomentResponse.success = true`, () => {
-            expect(MomentResponse.success).toBe(true);
+            expect(ack.MomentResponse[0].success).toBe(true);
         });
 
         test(`Assert MomentResponse.openFileAcks.length = ${assertItem.momentRequest.moments.length}`, () => {
-            expect(MomentResponse.openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
+            expect(ack.MomentResponse[0].openFileAcks.length).toEqual(assertItem.momentRequest.moments.length);
         });
 
         test(`Assert all MomentResponse.openFileAcks[].success = true`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 expect(ack.success).toBe(true);
             });
         });
 
         test(`Assert all openFileAcks[].fileId > 0`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 expect(ack.fileId).toBeGreaterThan(0);
             });
         });
 
         test(`Assert openFileAcks[].fileInfo.name`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfo.name).toEqual(assertItem.openFile.file + ".moment." + momentName[index]);
             });
         });
 
         test(`Assert openFileAcks[].fileInfoExtended`, () => {
-            MomentResponse.openFileAcks.map(ack => {
+            ack.MomentResponse[0].openFileAcks.map(ack => {
                 const coord = assertItem.setRegion.regionInfo.controlPoints;
                 expect(ack.fileInfoExtended.height).toEqual(coord[1].y + 1);
                 expect(ack.fileInfoExtended.width).toEqual(coord[1].x + 1);
@@ -158,13 +139,13 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
         });
 
         test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 76`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfoExtended.headerEntries.length).toEqual(76);
             });
         });
 
         test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 15`, () => {
-            MomentResponse.openFileAcks.map((ack, index) => {
+            ack.MomentResponse[0].openFileAcks.map((ack, index) => {
                 expect(ack.fileInfoExtended.computedEntries.length).toEqual(15);
             });
         });
@@ -182,22 +163,10 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
                     compressionType: CARTA.CompressionType.NONE,
                     compressionQuality: 0,
                 });
-                let ack;
-                do {
-                    ack = await Connection.receiveAny();
-                    switch (ack.constructor.name) {
-                        case "RasterTileSync":
-                            if (ack.endSync) {
-                                RasterTileSync.push(ack);
-                            }
-                            break;
-                        case "RasterTileData":
-                            RasterTileData.push(ack);
-                            break;
-                        default:
-                            break;
-                    }
-                } while (!(ack.constructor.name == "RasterTileSync" && ack.endSync));
+                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false).then(ack => {
+                    RasterTileSync.push(...ack.RasterTileSync.slice(-1));
+                    RasterTileData.push(...ack.RasterTileData);
+                });
             }
             RasterTileSync.map(ack => {
                 expect(ack.endSync).toBe(true);

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -8,6 +8,7 @@ let testSubdirectory = config.path.QA;
 let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let readFileTimeout = config.timeout.readFile;
+let saveFileTimeout = config.timeout.saveFile;
 let momentTimeout = config.timeout.moment;
 interface AssertItem {
     precisionDigit: number;
@@ -126,7 +127,7 @@ describe("MOMENTS_GENERATOR_SAVE: Testing moments generator for saving resultant
                     saveFileAck.push(await Connection.receive(CARTA.SaveFileAck));
                     await Wait(200);
                     expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[i]);
-                }, readFileTimeout);
+                }, saveFileTimeout);
             }
         }
 

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -116,18 +116,19 @@ describe("MOMENTS_GENERATOR_SAVE: Testing moments generator for saving resultant
 
     describe(`Save images`, () => {
         let saveFileAck: CARTA.SaveFileAck[] = [];
-        test(`Save all moment generated image and assert its fileId`, async () => {
-            for (let i = 0; i < FileId.length; i++) {
-                for (let j = 0; j < assertItem.saveFile.length; j++) {
+        for (let i = 0; i < assertItem.saveFile.length; i++) {
+            for (let j = 0; j < assertItem.saveFile[i].length; j++) {
+                test(`Save moment generated image ${assertItem.saveFile[i][j].outputFileName}`, async () => {
                     await Connection.send(CARTA.SaveFile, {
                         fileId: FileId[i],
                         ...assertItem.saveFile[i][j],
                     });
                     saveFileAck.push(await Connection.receive(CARTA.SaveFileAck));
-                }
-                expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[i]);
+                    await Wait(200);
+                    expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[i]);
+                }, readFileTimeout);
             }
-        }, readFileTimeout * FileId.length);
+        }
 
         test(`Assert all message.success = true`, () => {
             saveFileAck.map((ack, index) => {

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -5,6 +5,7 @@ import config from "./config.json";
 
 let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
+let saveSubdirectory = config.path.save;
 let connectTimeout = config.timeout.connection;
 let readFileTimeout = config.timeout.readFile;
 let momentTimeout = config.timeout.moment;
@@ -41,24 +42,24 @@ let assertItem: AssertItem = {
     saveFile: [
         [
             {
-                outputFileDirectory: 'tmp',
+                outputFileDirectory: saveSubdirectory,
                 outputFileName: 'HD163296_CO_2_1.fits.moment.average.fits',
                 outputFileType: CARTA.FileType.FITS,
             },
             {
-                outputFileDirectory: 'tmp',
+                outputFileDirectory: saveSubdirectory,
                 outputFileName: 'HD163296_CO_2_1.fits.moment.average.image',
                 outputFileType: CARTA.FileType.CASA,
             },
         ],
         [
             {
-                outputFileDirectory: 'tmp',
+                outputFileDirectory: saveSubdirectory,
                 outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.fits',
                 outputFileType: CARTA.FileType.FITS,
             },
             {
-                outputFileDirectory: 'tmp',
+                outputFileDirectory: saveSubdirectory,
                 outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.image',
                 outputFileType: CARTA.FileType.CASA,
             },

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -49,15 +49,15 @@ let assertItem: AssertItem = {
             },
             {
                 outputFileDirectory: saveSubdirectory,
-                outputFileName: 'HD163296_CO_2_1.fits.moment.average.image',
-                outputFileType: CARTA.FileType.CASA,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.fits',
+                outputFileType: CARTA.FileType.FITS,
             },
         ],
         [
             {
                 outputFileDirectory: saveSubdirectory,
-                outputFileName: 'HD163296_CO_2_1.fits.moment.integrated.fits',
-                outputFileType: CARTA.FileType.FITS,
+                outputFileName: 'HD163296_CO_2_1.fits.moment.average.image',
+                outputFileType: CARTA.FileType.CASA,
             },
             {
                 outputFileDirectory: saveSubdirectory,
@@ -121,12 +121,12 @@ describe("MOMENTS_GENERATOR_SAVE: Testing moments generator for saving resultant
             for (let j = 0; j < assertItem.saveFile[i].length; j++) {
                 test(`Save moment generated image ${assertItem.saveFile[i][j].outputFileName}`, async () => {
                     await Connection.send(CARTA.SaveFile, {
-                        fileId: FileId[i],
+                        fileId: FileId[j],
                         ...assertItem.saveFile[i][j],
                     });
                     saveFileAck.push(await Connection.receive(CARTA.SaveFileAck));
                     await Wait(200);
-                    expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[i]);
+                    expect(saveFileAck.slice(-1)[0].fileId).toEqual(FileId[j]);
                 }, saveFileTimeout);
             }
         }

--- a/src/test/TILE_DATA_REQUEST.test.ts
+++ b/src/test/TILE_DATA_REQUEST.test.ts
@@ -17,7 +17,7 @@ interface IRasterTileDataExt extends CARTA.IRasterTileData {
 }
 interface AssertItem {
     precisionDigit: number;
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     fileOpen: CARTA.IOpenFile;
     fileOpenAck: CARTA.IOpenFileAck;
     initTilesReq: CARTA.IAddRequiredTiles;
@@ -29,7 +29,7 @@ interface AssertItem {
 }
 let assertItem: AssertItem = {
     precisionDigit: 4,
-    register: {
+    registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
     },
@@ -157,21 +157,18 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("CHECK_RASTER_TILE_DATA: Testing data values at different layers in RASTER_TILE_DATA", () => {
+describe("TILE_DATA_REQUEST: Testing data values at different layers in RASTER_TILE_DATA", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     test(`(Step 0) Connection open? | `, () => {
         expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
     });
 
-    let RasterTileData: CARTA.RasterTileData;
-    let RasterTileDataTemp2: CARTA.RasterTileData;
     describe(`read the file "${assertItem.fileOpen.file}" on folder "${testSubdirectory}"`, () => {
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });

--- a/src/test/TILE_DATA_REQUEST.test.ts
+++ b/src/test/TILE_DATA_REQUEST.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client } from "./CLIENT";
+import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 const WebSocket = require('isomorphic-ws');
 
@@ -23,7 +23,6 @@ interface AssertItem {
     initTilesReq: CARTA.IAddRequiredTiles;
     initSetCursor: CARTA.ISetCursor;
     initSpatialReq: CARTA.ISetSpatialRequirements;
-    setImageChannel: CARTA.ISetImageChannels;
     rasterTileData: IRasterTileDataExt;
     addRequiredTilesGroup: CARTA.IAddRequiredTiles[];
     rasterTileDataGroup: IRasterTileDataExt[];
@@ -158,7 +157,7 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers in RASTER_TILE_DATA", () => {
+describe("CHECK_RASTER_TILE_DATA: Testing data values at different layers in RASTER_TILE_DATA", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
@@ -171,7 +170,7 @@ describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers i
         expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
     });
 
-    let RasterTileDataTemp: CARTA.RasterTileData;
+    let RasterTileData: CARTA.RasterTileData;
     let RasterTileDataTemp2: CARTA.RasterTileData;
     describe(`read the file "${assertItem.fileOpen.file}" on folder "${testSubdirectory}"`, () => {
         beforeAll(async () => {
@@ -180,87 +179,29 @@ describe("CHECK_RASTER_TILE_DATA test: Testing data values at different layers i
 
         test(`OpenFileAck? | `, async () => {
             expect(Connection.connection.readyState).toBe(WebSocket.OPEN);
-            await Connection.send(CARTA.OpenFile, assertItem.fileOpen);
-            let temp1 = await Connection.receive(CARTA.OpenFileAck)
-            // console.log(temp1)
-        }, openFileTimeout);
-
-        test(`RegionHistogramData (would pass over if trying several times)? | `, async () => {
-            let temp2 = await Connection.receive(CARTA.RegionHistogramData);
-            // console.log(temp2)
+            await Connection.openFile(assertItem.fileOpen);
         }, openFileTimeout);
 
         let ack: AckStream;
-        test(`RasterTileData * 4 + SpatialProfileData * 1 + RasterTileSync *2 (start & end)? |`, async () => {
+        test(`Receive stream until RasterTileSync.endSync = True |`, async () => {
             await Connection.send(CARTA.AddRequiredTiles, assertItem.initTilesReq);
             await Connection.send(CARTA.SetCursor, assertItem.initSetCursor);
             await Connection.send(CARTA.SetSpatialRequirements, assertItem.initSpatialReq);
-            ack = await Connection.stream(assertItem.initTilesReq.tiles.length + 3) as AckStream;
-            console.log(ack);
-            RasterTileDataTemp = ack.RasterTileData
-            // console.log(RasterTileDataTemp)
+            ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
         }, readFileTimeout);
 
         assertItem.rasterTileData.tiles.map((tiles, index) => {
             describe(`(Step1-3) Check each RASTER_TILE_DATA`, () => {
                 test(`(#${index})RASTER_TILE_DATA.tiles.length = 1 |`, () => {
-                    expect(RasterTileDataTemp[index].tiles.length).toBe(assertItem.rasterTileData.assert[index].lengthTiles);
+                    expect(ack.RasterTileData[index].tiles.length).toBe(assertItem.rasterTileData.assert[index].lengthTiles);
                 });
 
                 test(`(#${index})RASTER_TILE_DATA.tiles[0].x = ${tiles.x} & RASTER_TILE_DATA.tiles[0].y = ${tiles.y} & RASTER_TILE_DATA.tiles[0].layer = ${tiles.layer}|`, () => {
-                    let TempTiles = assertItem.rasterTileData.tiles.filter(f => f.x === RasterTileDataTemp[index].tiles[0].x && f.y === RasterTileDataTemp[index].tiles[0].y && f.layer === RasterTileDataTemp[index].tiles[0].layer)
-                    // console.log(TempTiles);
+                    let TempTiles = assertItem.rasterTileData.tiles.filter(f => f.x === ack.RasterTileData[index].tiles[0].x && f.y === ack.RasterTileData[index].tiles[0].y && f.layer === ack.RasterTileData[index].tiles[0].layer);
                     expect(TempTiles).toBeDefined();
                 })
             });
         });
-
-//        assertItem.rasterTileDataGroup.map((rasterTileData, index) => {
-//            describe(`ADD_REQUIRED_TILES ${assertItem.addRequiredTilesGroup[index].tiles}`, () => {
-//                let ack2: AckStream;
-//                if (rasterTileData.tiles.length) {
-//                    test(`RASTER_TILE_DATA x${rasterTileData.tiles.length} should arrive within ${readFileTimeout} ms`, async () => {
-//                        await Connection.send(CARTA.AddRequiredTiles, assertItem.addRequiredTilesGroup[index]);
-//                        ack2 = await Connection.stream(assertItem.addRequiredTilesGroup[index].tiles.length + 2) as AckStream;
-//                        console.log(ack2) //RasterTileData * 3 + RasterTileSync *2 (start & end)?
-//                        // ack2 = await Connection.stream(assertItem.rasterTileData.tiles.length) as AckStream;
-//                        expect(ack2.RasterTileData.length).toEqual(rasterTileData.tiles.length);
-//                        RasterTileDataTemp2 = ack2.RasterTileData
-//                    }, readFileTimeout);
-//
-//                    if (index == 0) {
-//                        assertItem.rasterTileDataGroup[index].tiles.map((tiles, index2) => {
-//                            describe(`(Step4-7) Check each RASTER_TILE_DATA`, () => {
-//                                test(`(#${index2})RASTER_TILE_DATA.tiles.length = 1 |`, () => {
-//                                    expect(RasterTileDataTemp2[index2].tiles.length).toBe(assertItem.rasterTileDataGroup[index].assert[index2].lengthTiles);
-//                                });
-//
-//                                test(`(#${index2})RASTER_TILE_DATA.tiles[0].x = ${tiles.x} & RASTER_TILE_DATA.tiles[0].y = ${tiles.y} & RASTER_TILE_DATA.tiles[0].layer = ${tiles.layer}|`, () => {
-//                                    let TempTiles = assertItem.rasterTileDataGroup[index].tiles.filter(f => f.x === RasterTileDataTemp2[index2].tiles[0].x && f.y === RasterTileDataTemp2[index2].tiles[0].y && f.layer === RasterTileDataTemp2[index2].tiles[0].layer)
-//                                    // console.log(TempTiles);
-//                                    expect(TempTiles).toBeDefined();
-//                                });
-//
-//                            });
-//                        });
-//                    }
-//
-//                } else {
-//                    test(`RASTER_TILE_DATA should NOT arrive within ${readFileTimeout} ms`, async () => {
-//                        await Connection.send(CARTA.AddRequiredTiles, assertItem.addRequiredTilesGroup[index]);
-//                        await Connection.receive(CARTA.RasterTileData, readFileTimeout * .5, false);
-//                    }, readFileTimeout);
-//                }
-//
-//                test("Backend be still alive (After send/receive, plz try several times, because the backend may automatically restart!)", () => {
-//                    setTimeout(() => {
-//                        console.log('waiting for 100ms')
-//                    }, 100);
-//                    expect(Connection.connection.readyState).toEqual(W3CWebSocket.OPEN);
-//                });
-//            });
-//        });
-//
     });
     afterAll(() => Connection.close());
 });

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -10,7 +10,8 @@
         "region": "set_QA/set_QA_regionTest",
         "performance": "set_QA_performance",
         "moment": "set_HD163296",
-        "catalog": "carta_catalog_test"
+        "catalog": "carta_catalog_test",
+        "save": "tmp"
     },
     "timeout": {
         "connection": 1100,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -18,6 +18,7 @@
         "listFile": 1200,
         "openFile": 1300,
         "readFile": 4100,
+        "saveFile": 3000,
         "readLargeImage": 18000,
         "changeChannel": 3000,
         "playImages": 8000,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -11,7 +11,7 @@
         "performance": "set_QA_performance",
         "moment": "set_HD163296",
         "catalog": "carta_catalog_test",
-        "save": "tmp"
+        "save": "/tmp"
     },
     "timeout": {
         "connection": 1100,


### PR DESCRIPTION
To reduce the code complexity, we introduce a new function about receiving stream message until some condition.
This function can improve the issue about the number of returning messages is varied and the order is not consistent while we repeat testing.
Part of tests in this issue could support #150.