### PR TITLE
Mylin/%172 extrema

### DIFF
--- a/src/test/REGION_SPECTRAL_PROFILE_ELLIPSE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_ELLIPSE.test.ts
@@ -109,7 +109,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -129,7 +130,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -181,6 +183,11 @@ let assertItem: AssertItem = {
                     statsType: CARTA.StatsType.Max,
                     assertValues: [{ index: 10, value: 0.02959144 }],
                 },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
+                    assertValues: [{ index: 10, value: 0.02959144 }],
+                },
             ],
         },
         {
@@ -226,6 +233,11 @@ let assertItem: AssertItem = {
                 {
                     coordinate: "z",
                     statsType: CARTA.StatsType.Max,
+                    assertValues: [{ index: 0, value: NaN }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
                     assertValues: [{ index: 0, value: NaN }],
                 },
             ],

--- a/src/test/REGION_SPECTRAL_PROFILE_POLYGON.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_POLYGON.test.ts
@@ -109,7 +109,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -129,7 +130,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -181,6 +183,11 @@ let assertItem: AssertItem = {
                     statsType: CARTA.StatsType.Max,
                     assertValues: [{ index: 10, value: 0.02121421 }],
                 },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
+                    assertValues: [{ index: 10, value: 0.02121421 }],
+                },
             ],
         },
         {
@@ -226,6 +233,11 @@ let assertItem: AssertItem = {
                 {
                     coordinate: "z",
                     statsType: CARTA.StatsType.Max,
+                    assertValues: [{ index: 0, value: NaN }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
                     assertValues: [{ index: 0, value: NaN }],
                 },
             ],

--- a/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
@@ -87,6 +87,15 @@ let assertItem: AssertItem = {
             regionId: -1,
             regionInfo: {
                 regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 360, y: 490 }, { x: 0.5, y: 0.5 }],
+                rotation: 0.0,
+            }
+        },
+        {
+            fileId: 0,
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.RECTANGLE,
                 controlPoints: [{ x: 0, y: 522 }, { x: 4, y: 6 }],
                 rotation: 50.0,
             }
@@ -104,6 +113,10 @@ let assertItem: AssertItem = {
         {
             success: true,
             regionId: 3,
+        },
+        {
+            success: true,
+            regionId: 4,
         },
     ],
     setSpectralRequirements: [
@@ -152,6 +165,27 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             regionId: 3,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
+                    ],
+                }
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 4,
             spectralProfiles: [
                 {
                     coordinate: "z",
@@ -278,6 +312,58 @@ let assertItem: AssertItem = {
         },
         {
             regionId: 3,
+            progress: 1,
+            profile: [
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Sum,
+                    assertValues: [{ index: 10, value: 0.00006235 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.FluxDensity,
+                    assertValues: [{ index: 10, value: 0.00000286 }],
+                },
+                {
+                    coordinate: "z",
+                    profileLength: 25,
+                    statsType: CARTA.StatsType.Mean,
+                    assertValues: [{ index: 10, value: 0.00006235 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.RMS,
+                    assertValues: [{ index: 10, value: 0.00006235 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Sigma,
+                    assertValues: [{ index: 10, value: 0.0 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.SumSq,
+                    assertValues: [{ index: 10, value: 0.0 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Min,
+                    assertValues: [{ index: 10, value: 0.00006235 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Max,
+                    assertValues: [{ index: 10, value: 0.0000623 }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
+                    assertValues: [{ index: 10, value: 0.0000623 }],
+                },
+            ],
+        },
+        {
+            regionId: 4,
             progress: 1,
             profile: [
                 {
@@ -413,7 +499,7 @@ describe("REGION_SPECTRAL_PROFILE_RECTANGLE: Testing spectral profiler with rect
                         assertItem.spectralProfileData[index].profile.map(profile => {
                             let _returnedProfile = SpectralProfileData.profiles.find(f => f.statsType === profile.statsType);
                             profile.assertValues.map(assertVal => {
-                                if (isNaN(assertVal.value)) {
+                                if (isNaN(assertVal.value) || isNaN(_returnedProfile.values[assertVal.index])) {
                                     expect(isNaN(_returnedProfile.values[assertVal.index])).toBe(true);
                                 } else {
                                     expect(_returnedProfile.values[assertVal.index]).toBeCloseTo(assertVal.value, assertItem.precisionDigits);

--- a/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
@@ -499,7 +499,7 @@ describe("REGION_SPECTRAL_PROFILE_RECTANGLE: Testing spectral profiler with rect
                         assertItem.spectralProfileData[index].profile.map(profile => {
                             let _returnedProfile = SpectralProfileData.profiles.find(f => f.statsType === profile.statsType);
                             profile.assertValues.map(assertVal => {
-                                if (isNaN(assertVal.value) || isNaN(_returnedProfile.values[assertVal.index])) {
+                                if (isNaN(assertVal.value)) {
                                     expect(isNaN(_returnedProfile.values[assertVal.index])).toBe(true);
                                 } else {
                                     expect(_returnedProfile.values[assertVal.index]).toBeCloseTo(assertVal.value, assertItem.precisionDigits);

--- a/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
@@ -348,7 +348,7 @@ let assertItem: AssertItem = {
                 {
                     coordinate: "z",
                     statsType: CARTA.StatsType.Min,
-                    assertValues: [{ index: 10, value: 0.00006235 }],
+                    assertValues: [{ index: 10, value: 0.0000623 }],
                 },
                 {
                     coordinate: "z",

--- a/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
+++ b/src/test/REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts
@@ -122,7 +122,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -142,7 +143,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -162,7 +164,8 @@ let assertItem: AssertItem = {
                         CARTA.StatsType.Sigma,
                         CARTA.StatsType.SumSq,
                         CARTA.StatsType.Min,
-                        CARTA.StatsType.Max
+                        CARTA.StatsType.Max,
+                        CARTA.StatsType.Extrema
                     ],
                 }
             ],
@@ -214,6 +217,11 @@ let assertItem: AssertItem = {
                     statsType: CARTA.StatsType.Max,
                     assertValues: [{ index: 10, value: 0.0702243 }],
                 },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
+                    assertValues: [{ index: 10, value: 0.0702243 }],
+                },
             ],
         },
         {
@@ -261,6 +269,11 @@ let assertItem: AssertItem = {
                     statsType: CARTA.StatsType.Max,
                     assertValues: [{ index: 10, value: -0.00236961 }],
                 },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
+                    assertValues: [{ index: 10, value: -0.03209378 }],
+                },
             ],
         },
         {
@@ -306,6 +319,11 @@ let assertItem: AssertItem = {
                 {
                     coordinate: "z",
                     statsType: CARTA.StatsType.Max,
+                    assertValues: [{ index: 0, value: NaN }],
+                },
+                {
+                    coordinate: "z",
+                    statsType: CARTA.StatsType.Extrema,
                     assertValues: [{ index: 0, value: NaN }],
                 },
             ],

--- a/src/test/REGION_STATISTICS_ELLIPSE.test.ts
+++ b/src/test/REGION_STATISTICS_ELLIPSE.test.ts
@@ -195,34 +195,6 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.Extrema, value: NaN },
             ]
         },
-        {
-            regionId: 4,
-            statistics: [
-                { statsType: CARTA.StatsType.NumPixels, value: 0 },
-                { statsType: CARTA.StatsType.Sum, value: NaN },
-                { statsType: CARTA.StatsType.FluxDensity, value: NaN },
-                { statsType: CARTA.StatsType.Mean, value: NaN },
-                { statsType: CARTA.StatsType.RMS, value: NaN },
-                { statsType: CARTA.StatsType.Sigma, value: NaN },
-                { statsType: CARTA.StatsType.SumSq, value: NaN },
-                { statsType: CARTA.StatsType.Min, value: NaN },
-                { statsType: CARTA.StatsType.Max, value: NaN },
-            ]
-        },
-        {
-            regionId: -1,
-            statistics: [
-                { statsType: CARTA.StatsType.NumPixels, value: 216248 },
-                { statsType: CARTA.StatsType.Sum, value: -7.6253559 },
-                { statsType: CARTA.StatsType.FluxDensity, value: -0.35032758 },
-                { statsType: CARTA.StatsType.Mean, value: -3.52620875e-05 },
-                { statsType: CARTA.StatsType.RMS, value: 0.00473442 },
-                { statsType: CARTA.StatsType.Sigma, value: 0.0047343 },
-                { statsType: CARTA.StatsType.SumSq, value: 4.84713562 },
-                { statsType: CARTA.StatsType.Min, value: -0.03958673 },
-                { statsType: CARTA.StatsType.Max, value: 0.04523611 },
-            ]
-        },
     ],
     precisionDigits: 4,
 };

--- a/src/test/REGION_STATISTICS_ELLIPSE.test.ts
+++ b/src/test/REGION_STATISTICS_ELLIPSE.test.ts
@@ -112,7 +112,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -127,7 +128,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -142,7 +144,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
     ],
@@ -159,6 +162,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.00468503 },
                 { statsType: CARTA.StatsType.Min, value: -0.01768329 },
                 { statsType: CARTA.StatsType.Max, value: 0.02505673 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02505672 },
             ]
         },
         {
@@ -173,6 +177,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.00017065 },
                 { statsType: CARTA.StatsType.Min, value: -0.00590614 },
                 { statsType: CARTA.StatsType.Max, value: 0.00654556 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.00654555 },
             ]
         },
         {
@@ -187,6 +192,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: NaN },
                 { statsType: CARTA.StatsType.Min, value: NaN },
                 { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
             ]
         },
         {

--- a/src/test/REGION_STATISTICS_POLYGON.test.ts
+++ b/src/test/REGION_STATISTICS_POLYGON.test.ts
@@ -154,7 +154,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -169,7 +170,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -184,7 +186,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -199,7 +202,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -214,7 +218,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -229,7 +234,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
     ],
@@ -246,6 +252,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.01752493 },
                 { statsType: CARTA.StatsType.Min, value: -0.01051447 },
                 { statsType: CARTA.StatsType.Max, value: 0.01217441 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.01217440 },
             ]
         },
         {
@@ -260,6 +267,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.01179662 },
                 { statsType: CARTA.StatsType.Min, value: -0.01994896 },
                 { statsType: CARTA.StatsType.Max, value: 0.0235076 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02350760 },
             ]
         },
         {
@@ -274,6 +282,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: NaN },
                 { statsType: CARTA.StatsType.Min, value: NaN },
                 { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
             ]
         },
         {
@@ -288,6 +297,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 4.84713562 },
                 { statsType: CARTA.StatsType.Min, value: -0.03958673 },
                 { statsType: CARTA.StatsType.Max, value: 0.04523611 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.04523611 },
             ]
         },
         {
@@ -302,6 +312,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: NaN },
                 { statsType: CARTA.StatsType.Min, value: NaN },
                 { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
             ]
         },
         {
@@ -316,6 +327,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 1.32743435e-06 },
                 { statsType: CARTA.StatsType.Min, value: -0.00115214 },
                 { statsType: CARTA.StatsType.Max, value: -0.00115214 },
+                { statsType: CARTA.StatsType.Extrema, value: -0.00115214 },
             ]
         },
     ],

--- a/src/test/REGION_STATISTICS_RECTANGLE.test.ts
+++ b/src/test/REGION_STATISTICS_RECTANGLE.test.ts
@@ -1,3 +1,4 @@
+import { CartaBackend } from "action/SocketOperation";
 import { CARTA } from "carta-protobuf";
 
 import { Client, AckStream } from "./CLIENT";
@@ -116,7 +117,6 @@ let assertItem: AssertItem = {
             success: true,
             regionId: 5,
         },
-        {},
     ],
     setStatsRequirements: [
         {
@@ -131,7 +131,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -146,7 +147,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -161,7 +163,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -176,7 +179,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
         {
@@ -191,7 +195,8 @@ let assertItem: AssertItem = {
                 CARTA.StatsType.Sigma,
                 CARTA.StatsType.SumSq,
                 CARTA.StatsType.Min,
-                CARTA.StatsType.Max
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
             ],
         },
     ],
@@ -208,6 +213,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.00182528 },
                 { statsType: CARTA.StatsType.Min, value: -0.00358113 },
                 { statsType: CARTA.StatsType.Max, value: 0.00793927 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.00793926 },
             ]
         },
         {
@@ -222,6 +228,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.00048188 },
                 { statsType: CARTA.StatsType.Min, value: -0.0095625 },
                 { statsType: CARTA.StatsType.Max, value: 0.00694707 },
+                { statsType: CARTA.StatsType.Extrema, value: -0.00956249 },
             ]
         },
         {
@@ -236,6 +243,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: 0.00512399 },
                 { statsType: CARTA.StatsType.Min, value: -0.01768329 },
                 { statsType: CARTA.StatsType.Max, value: 0.02505673 },
+                { statsType: CARTA.StatsType.Extrema, value: 0.02505672 },
             ]
         },
         {
@@ -250,6 +258,7 @@ let assertItem: AssertItem = {
                 { statsType: CARTA.StatsType.SumSq, value: NaN },
                 { statsType: CARTA.StatsType.Min, value: NaN },
                 { statsType: CARTA.StatsType.Max, value: NaN },
+                { statsType: CARTA.StatsType.Extrema, value: NaN },
             ]
         },
         {


### PR DESCRIPTION
Close #171 
add a single pixel square region to REGION_SPECTRAL_PROFILE_RECTANGLE.test.ts, it named region id = 3.

Close #172 
add  stat type: extrema to REGION_SPECTRAL_PROFILE*.test.ts (except REGION_SPECTRAL_PROFILE_STOKES.test.ts) & REGION_STATISTICS*.test.ts

[ICD test cases: Spectral profiler](https://docs.google.com/document/d/15cy03dK0p1OGD5vQtduxNX8gEO-t9rmy5yKPy5z-Ovc/edit#heading=h.3f8qkqrtozdq) & [ICD test cases: region statistics](https://docs.google.com/document/d/13rfStgw6gHOQydoiY9OOj9qcUlQsvtXpzWS7N33EeIo/edit#heading=h.qlk3b6616vfh)
documents have been updated.