### PR TITLE
Skip to test the external web socket server

### DIFF
--- a/src/test/ACCESS_WEBSOCKET.test.ts
+++ b/src/test/ACCESS_WEBSOCKET.test.ts
@@ -2,9 +2,10 @@ import config from "./config.json";
 let testServerUrl = config.serverURL;
 let connectTimeout = config.timeout.connection;
 const WebSocket = require('isomorphic-ws');
-describe("ACCESS_WEBSOCKET tests: Testing connections to the websocket server", () => {
+
+describe("ACCESS_WEBSOCKET: Testing connections to the websocket server", () => {
     let testRemoteWebsocketSite = "wss://echo.websocket.org";
-    test(`should connect to "${testRemoteWebsocketSite}".`, done => {
+    test.skip(`should connect to "${testRemoteWebsocketSite}".`, done => {
         // Construct a Websocket
         let Connection = new WebSocket(testRemoteWebsocketSite);
 
@@ -22,20 +23,20 @@ describe("ACCESS_WEBSOCKET tests: Testing connections to the websocket server", 
 
         let Connection = new WebSocket(testServerUrl);
         expect(Connection.readyState).toBe(WebSocket.CONNECTING);
-        
+
         Connection.onopen = OnOpen;
 
-        function OnOpen (this, ev: Event) {
+        function OnOpen(this, ev: Event) {
             expect(this.readyState).toBe(WebSocket.OPEN);
             if (config.log.event) {
                 console.log(testServerUrl + "  opened");
             }
-            
+
             this.close();
             expect(this.readyState).toBe(WebSocket.CLOSING);
 
             Connection.onclose = OnClose;
-            function OnClose (this, ev: CloseEvent) {
+            function OnClose(this, ev: CloseEvent) {
                 expect(this.readyState).toBe(WebSocket.CLOSED);
                 if (config.log.event) {
                     console.log(testServerUrl + "  closed");


### PR DESCRIPTION
Due to the potential issue about the external network, which might not relate to the ICD issue, we skip the echo test of websocket in an external service.