### PR TITLE
Patch for openFile related test

### DIFF
--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -625,10 +625,19 @@ export class Client {
         await this.send(CARTA.RegisterViewer, registerViewer);
         return await this.receive(CARTA.RegisterViewerAck) as CARTA.RegisterViewerAck;
     }
-    /// Send open_file and receive its returning message
 
-    async openFile(file): Promise<IOpenFile> {
-        await this.send(CARTA.OpenFile, file);
+    /// Send open_file and receive its returning message
+    async openFile(openFile: any): Promise<IOpenFile> {
+        await this.send(CARTA.FileListRequest, { directory: "$BASE" });
+        let bathPath: string = (await this.receive(CARTA.FileListResponse) as CARTA.FileListResponse).directory;
+        console.log(`${bathPath}/${openFile.directory}`);
+        await this.send(CARTA.OpenFile, {
+            directory: `${bathPath}/${openFile.directory}`,
+            file: openFile.file,
+            hdu: openFile.hdu,
+            fileId: openFile.fileId,
+            renderMode: openFile.renderMode,
+        });
         let ack = await this.stream(2) as AckStream;
         return {
             OpenFileAck: ack.Responce[0],


### PR DESCRIPTION
Upgrade Client.openFile() if the backend offers no BASE path. Since the backend changes the rule to address the base path, the frontend should active request a $BASE list from the backend once before sending any requests related to the directory for file path.
Patch the Client.openFile() function by request fileList for $BASE, so any test involved this function could works well as before we could address a relative path under $BASE.