### PR TITLE
Mylin/#187 improve spectral line query

### DIFF
--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -314,6 +314,7 @@ export class Client {
             ScriptingResponse: [],
             MomentResponse: [],
             MomentProgress: [],
+            SpectralLineResponse: [],
         };
 
         return new Promise<AckStream>(resolve => {
@@ -376,6 +377,9 @@ export class Client {
                         break;
                     case CARTA.MomentResponse:
                         ack.MomentResponse.push(data);
+                        break;
+                    case CARTA.SpectralLineResponse:
+                        ack.SpectralLineResponse.push(data);
                         break;
                 }
 
@@ -518,6 +522,7 @@ export class Client {
                         break;
                     case CARTA.SpectralLineResponse:
                         ack.SpectralLineResponse.push(data);
+                        break;
                 }
                 if (isDone(eventType, data, ack)) {
                     resolve(ack);

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -452,6 +452,7 @@ export class Client {
             ScriptingResponse: [],
             MomentResponse: [],
             MomentProgress: [],
+            SpectralLineResponse:[],
         };
 
         return new Promise<AckStream>((resolve, reject) => {
@@ -515,6 +516,8 @@ export class Client {
                     case CARTA.MomentResponse:
                         ack.MomentResponse.push(data);
                         break;
+                    case CARTA.SpectralLineResponse:
+                        ack.SpectralLineResponse.push(data);
                 }
                 if (isDone(eventType, data, ack)) {
                     resolve(ack);
@@ -651,6 +654,7 @@ export interface AckStream {
     ScriptingResponse: CARTA.ScriptingResponse[];
     MomentResponse: CARTA.MomentResponse[];
     MomentProgress: CARTA.MomentProgress[];
+    SpectralLineResponse: CARTA.SpectralLineResponse[];
 }
 interface ProcessedSpatialProfile extends CARTA.ISpatialProfile { values: Float32Array; }
 function processSpatialProfile(profile: CARTA.ISpatialProfile): ProcessedSpatialProfile {

--- a/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
@@ -89,7 +89,7 @@ assertItem.setSpectralLineReq.map((request, index) => {
         });
 
         describe("Query the spectral line directly with a wide freq range:", () => {
-            let response: CARTA.SpectralLineResponse;
+            let response: AckStream;
             let response2: any;
             test(`(Step 1) Sent & return SPECTRAL_LINE_RESPONSE within ${spectralLineRequest}ms`, async () => {
                 await Connection.send(CARTA.SpectralLineRequest, request);


### PR DESCRIPTION
Fixed #187 
Each spectral line query has its own session, then it could prevent the sequence disorder. 
Improve the OpenFile to fit the upgrade CLIENT.ts