### PR TITLE
Patch for failed CI

### DIFF
--- a/src/test/CASA_REGION_EXPORT.test.ts
+++ b/src/test/CASA_REGION_EXPORT.test.ts
@@ -322,8 +322,9 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
             for (let region of assertItem.setRegion) {
                 await Connection.send(CARTA.SetRegion, region);
                 await Connection.receive(CARTA.SetRegionAck);
@@ -336,7 +337,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ExportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     exportRegionAck = (await Connection.streamUntil(type => type == CARTA.ExportRegionAck)).Responce[0] as CARTA.ExportRegionAck;
                 }, exportTimeout);
@@ -358,7 +359,7 @@ describe("CASA_REGION_EXPORT test: Testing export of CASA region to a file", () 
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)

--- a/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
@@ -68,8 +68,9 @@ describe("CASA_REGION_IMPORT_EXCEPTION: Testing import/export of CASA region for
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(() => {
+                basePath = Connection.Property.basePath;
+            });
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -78,7 +79,7 @@ describe("CASA_REGION_IMPORT_EXCEPTION: Testing import/export of CASA region for
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 }, importTimeout);

--- a/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts
@@ -35,14 +35,14 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet2_pix.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
             },
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet2_world.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
@@ -65,16 +65,21 @@ describe("CASA_REGION_IMPORT_EXCEPTION: Testing import/export of CASA region for
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
 
+        let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            await Connection.openFile(assertItem.openFile);
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
             describe(`Import "${assertItem.importRegion[idxRegion].file}"`, () => {
                 let importRegionAck: CARTA.ImportRegionAck;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.importRegion[idxRegion]);
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.importRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 }, importTimeout);
 

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -59,7 +59,7 @@ let assertItem: AssertItem = {
     importRegion:
     {
         contents: [],
-        directory: regionSubdirectory,
+        // directory: regionSubdirectory,
         file: "M17_SWex_testRegions_pix.crtf",
         groupId: 0,
         type: CARTA.FileType.CRTF,
@@ -113,7 +113,7 @@ let assertItem: AssertItem = {
         [
             {
                 coordType: CARTA.CoordinateType.WORLD,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.crtf",
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
@@ -130,7 +130,7 @@ let assertItem: AssertItem = {
             },
             {
                 coordType: CARTA.CoordinateType.PIXEL,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
                 fileId: 0,
                 type: CARTA.FileType.CRTF,
@@ -161,14 +161,14 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
             },
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.crtf",
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
@@ -204,9 +204,11 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+        let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            await Connection.openFile(assertItem.openFile);
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
         });
 
         test(`OpenFileAck & RegionHistogramData? | `, async () => {
@@ -219,7 +221,10 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             let importRegionAck: CARTA.ImportRegionAck;
             let importRegionAckProperties: any[];
             test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                await Connection.send(CARTA.ImportRegion, assertItem.importRegion);
+                await Connection.send(CARTA.ImportRegion, {
+                    ...assertItem.importRegion,
+                    directory: basePath + "/" + regionSubdirectory,
+                });
                 importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 importRegionAckProperties = Object.keys(importRegionAck.regions);
                 if (importRegionAck.message != '') {
@@ -250,8 +255,11 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
                 let exportRegionAck: CARTA.ExportRegionAck;
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ExportRegion, assertItem.exportRegion[idxRegion]);
-                    exportRegionAck = await Connection.receive(CARTA.ExportRegionAck) as CARTA.ExportRegionAck;
+                    await Connection.send(CARTA.ExportRegion, {
+                        ...assertItem.exportRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    exportRegionAck = (await Connection.streamUntil(type => type == CARTA.ExportRegionAck)).Responce[0] as CARTA.ExportRegionAck;
                 }, exportTimeout);
 
                 test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
@@ -269,8 +277,11 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 let importRegionAck: CARTA.ImportRegionAck;
                 let importRegionAckProperties: any;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.exportRegion[idxRegion]);
-                    importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.exportRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions);
                     if (importRegionAck.message != '') {
                         console.warn(importRegionAck.message);

--- a/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/CASA_REGION_IMPORT_EXPORT.test.ts
@@ -207,8 +207,9 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         });
 
         test(`OpenFileAck & RegionHistogramData? | `, async () => {
@@ -223,7 +224,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
             test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                 await Connection.send(CARTA.ImportRegion, {
                     ...assertItem.importRegion,
-                    directory: basePath + "/" + regionSubdirectory,
+                    directory: basePath + regionSubdirectory,
                 });
                 importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 importRegionAckProperties = Object.keys(importRegionAck.regions);
@@ -257,7 +258,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ExportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     exportRegionAck = (await Connection.streamUntil(type => type == CARTA.ExportRegionAck)).Responce[0] as CARTA.ExportRegionAck;
                 }, exportTimeout);
@@ -279,7 +280,7 @@ describe("CASA_REGION_IMPORT_EXPORT: Testing import/export of CASA region format
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions);

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -10,7 +10,7 @@ let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     setCursor: CARTA.ISetCursor;
     addTilesRequire: CARTA.IAddRequiredTiles;
@@ -20,7 +20,7 @@ interface AssertItem {
 };
 
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
     },
@@ -49,13 +49,13 @@ let assertItem: AssertItem = {
             {
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet1_world.crtf",
             },
             {
                 groupId: 0,
                 type: CARTA.FileType.CRTF,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet1_pix.crtf",
             },
         ],
@@ -232,15 +232,15 @@ describe("CASA_REGION_IMPORT_INTERNAL: Testing import of CASA region files made 
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+        let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -248,8 +248,11 @@ describe("CASA_REGION_IMPORT_INTERNAL: Testing import of CASA region files made 
                 let importRegionAck: CARTA.ImportRegionAck;
                 let importRegionAckProperties: any;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.importRegion[idxRegion]);
-                    importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.importRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)
                 }, importTimeout);
 

--- a/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/CASA_REGION_IMPORT_INTERNAL.test.ts
@@ -239,8 +239,9 @@ describe("CASA_REGION_IMPORT_INTERNAL: Testing import of CASA region files made 
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -250,7 +251,7 @@ describe("CASA_REGION_IMPORT_INTERNAL: Testing import of CASA region files made 
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -7,7 +7,6 @@ const WebSocket = require('isomorphic-ws');
 export interface IOpenFile {
     OpenFileAck: CARTA.OpenFileAck;
     RegionHistogramData: CARTA.RegionHistogramData;
-    basePath: string;
 }
 export class Client {
     IcdVersion: number = 19;
@@ -84,7 +83,10 @@ export class Client {
         }
         return ret;
     }
-    static eventCount = { value: 0 };
+    static staticValue = { eventCount: 0 };
+    Property = {
+        basePath: "./",
+    };
     connection: WebSocket;
     // Construct a websocket connection to url
     constructor(url: string) {
@@ -132,7 +134,7 @@ export class Client {
             const eventHeader32 = new Uint32Array(eventData.buffer, 4, 1);
             eventHeader16[0] = this.CartaTypeValue(cartaType);
             eventHeader16[1] = this.IcdVersion;
-            eventHeader32[0] = Client.eventCount.value++; // eventCounter;
+            eventHeader32[0] = Client.staticValue.eventCount++; // eventCounter;
             if (config.log.event) {
                 console.log(`${cartaType.name} => #${eventHeader32[0]} @ ${performance.now()}`);
             }
@@ -457,7 +459,7 @@ export class Client {
             ScriptingResponse: [],
             MomentResponse: [],
             MomentProgress: [],
-            SpectralLineResponse:[],
+            SpectralLineResponse: [],
         };
 
         return new Promise<AckStream>((resolve, reject) => {
@@ -638,9 +640,12 @@ export class Client {
     /// Send open_file and receive its returning message
     async openFile(openFile: any): Promise<IOpenFile> {
         await this.send(CARTA.FileListRequest, { directory: "$BASE" });
-        let bathPath: string = (await this.receive(CARTA.FileListResponse) as CARTA.FileListResponse).directory;
+        this.Property.basePath = (await this.receive(CARTA.FileListResponse) as CARTA.FileListResponse).directory + "/";
+        if (config.log.event) {
+            console.log(this.Property);
+        }
         await this.send(CARTA.OpenFile, {
-            directory: `${bathPath}/${openFile.directory}`,
+            directory: this.Property.basePath + openFile.directory,
             file: openFile.file,
             hdu: openFile.hdu,
             fileId: openFile.fileId,
@@ -650,7 +655,6 @@ export class Client {
         return {
             OpenFileAck: ack.Responce[0],
             RegionHistogramData: ack.RegionHistogramData[0],
-            basePath: bathPath,
         };
     }
 };

--- a/src/test/CLIENT.ts
+++ b/src/test/CLIENT.ts
@@ -7,6 +7,7 @@ const WebSocket = require('isomorphic-ws');
 export interface IOpenFile {
     OpenFileAck: CARTA.OpenFileAck;
     RegionHistogramData: CARTA.RegionHistogramData;
+    basePath: string;
 }
 export class Client {
     IcdVersion: number = 19;
@@ -638,7 +639,6 @@ export class Client {
     async openFile(openFile: any): Promise<IOpenFile> {
         await this.send(CARTA.FileListRequest, { directory: "$BASE" });
         let bathPath: string = (await this.receive(CARTA.FileListResponse) as CARTA.FileListResponse).directory;
-        console.log(`${bathPath}/${openFile.directory}`);
         await this.send(CARTA.OpenFile, {
             directory: `${bathPath}/${openFile.directory}`,
             file: openFile.file,
@@ -650,6 +650,7 @@ export class Client {
         return {
             OpenFileAck: ack.Responce[0],
             RegionHistogramData: ack.RegionHistogramData[0],
+            basePath: bathPath,
         };
     }
 };

--- a/src/test/DS9_REGION_EXPORT.test.ts
+++ b/src/test/DS9_REGION_EXPORT.test.ts
@@ -322,8 +322,9 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
             for (let region of assertItem.setRegion) {
                 await Connection.send(CARTA.SetRegion, region);
                 await Connection.receive(CARTA.SetRegionAck);
@@ -336,7 +337,7 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ExportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     exportRegionAck = await Connection.receive(CARTA.ExportRegionAck) as CARTA.ExportRegionAck;
                     // console.log(exportRegionAck)
@@ -359,7 +360,7 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)

--- a/src/test/DS9_REGION_EXPORT.test.ts
+++ b/src/test/DS9_REGION_EXPORT.test.ts
@@ -18,7 +18,7 @@ interface ImportRegionAckExt extends CARTA.IImportRegionAck {
     };
 };
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     precisionDigits: number;
     setRegion: CARTA.ISetRegion[];
@@ -28,7 +28,7 @@ interface AssertItem {
     importRegionAck: ImportRegionAckExt[];
 };
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         apiKey: "",
         clientFeatureFlags: 5,
@@ -209,7 +209,7 @@ let assertItem: AssertItem = {
         [
             {
                 coordType: CARTA.CoordinateType.WORLD,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_handMadeRegions_world.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -235,7 +235,7 @@ let assertItem: AssertItem = {
             },
             {
                 coordType: CARTA.CoordinateType.PIXEL,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_handMadeRegions_pix.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -275,14 +275,14 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_handMadeRegions_world.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
             },
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_handMadeRegions_pix.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -314,16 +314,16 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file} and set regions"`, () => {
 
+        let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2); // OpenFileAck | RegionHistogramData
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
             for (let region of assertItem.setRegion) {
                 await Connection.send(CARTA.SetRegion, region);
                 await Connection.receive(CARTA.SetRegionAck);
@@ -334,7 +334,10 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
             describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
                 let exportRegionAck: CARTA.ExportRegionAck;
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ExportRegion, assertItem.exportRegion[idxRegion]);
+                    await Connection.send(CARTA.ExportRegion, {
+                        ...assertItem.exportRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
                     exportRegionAck = await Connection.receive(CARTA.ExportRegionAck) as CARTA.ExportRegionAck;
                     // console.log(exportRegionAck)
                 }, exportTimeout);
@@ -354,7 +357,10 @@ describe("DS9_REGION_EXPORT test: Testing export of DS9 region to a file", () =>
                 let importRegionAck: CARTA.ImportRegionAck;
                 let importRegionAckProperties: any;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.exportRegion[idxRegion]);
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.importRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
                     importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)
                 }, importTimeout);

--- a/src/test/DS9_REGION_IMPORT_DOS.test.ts
+++ b/src/test/DS9_REGION_IMPORT_DOS.test.ts
@@ -104,8 +104,9 @@ describe("DS9_REGION_IMPORT_DOS: Testing import of DS9 region files made on DOS 
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         }, openfileTimeout);
 
         let importRegionAck: CARTA.ImportRegionAck[] = [];
@@ -114,7 +115,7 @@ describe("DS9_REGION_IMPORT_DOS: Testing import of DS9 region files made on DOS 
                 test(`IMPORT_REGION_ACK${idxRegion} should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck.push(await (await Connection.streamUntil(type => type==CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck);
                 }, importTimeout);

--- a/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
@@ -67,8 +67,9 @@ describe("CASA_REGION_IMPORT_EXCEPTION test: Testing import/export of CASA regio
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -77,7 +78,7 @@ describe("CASA_REGION_IMPORT_EXCEPTION test: Testing import/export of CASA regio
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type==CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 }, importTimeout);

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -207,8 +207,9 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         });
 
         describe(`Import "${assertItem.importRegion.file}"`, () => {
@@ -217,7 +218,7 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
             test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                 await Connection.send(CARTA.ImportRegion, {
                     ...assertItem.importRegion,
-                    directory: basePath + "/" + regionSubdirectory,
+                    directory: basePath + regionSubdirectory,
                 });
                 importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 if (importRegionAck.message != '') {
@@ -251,7 +252,7 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ExportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     exportRegionAck = (await Connection.streamUntil(type => type == CARTA.ExportRegionAck)).Responce[0] as CARTA.ExportRegionAck;
                 }, exportTimeout);
@@ -273,7 +274,7 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.exportRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     if (importRegionAck.message != '') {

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -19,7 +19,7 @@ interface ImportRegionAckExt2 extends CARTA.IImportRegionAck {
 };
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     setCursor: CARTA.ISetCursor;
     addTilesRequire: CARTA.IAddRequiredTiles;
@@ -32,7 +32,7 @@ interface AssertItem {
     importRegionAck2: ImportRegionAckExt2[];
 };
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
     },
@@ -113,7 +113,7 @@ let assertItem: AssertItem = {
         [
             {
                 coordType: CARTA.CoordinateType.WORLD,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -130,7 +130,7 @@ let assertItem: AssertItem = {
             },
             {
                 coordType: CARTA.CoordinateType.PIXEL,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.reg",
                 fileId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -161,14 +161,14 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_world.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
             },
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_testRegions_pix_export_to_pix.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
@@ -200,23 +200,26 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+        let basePath: string;
         beforeAll(async () => {
-            await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            await Connection.send(CARTA.CloseFile, { fileId: -1, });
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
         });
 
         describe(`Import "${assertItem.importRegion.file}"`, () => {
             let importRegionAck: CARTA.ImportRegionAck;
             let importRegionAckProperties: any[];
             test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                await Connection.send(CARTA.ImportRegion, assertItem.importRegion);
-                importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
+                await Connection.send(CARTA.ImportRegion, {
+                    ...assertItem.importRegion,
+                    directory: basePath + "/" + regionSubdirectory,
+                });
+                importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                 if (importRegionAck.message != '') {
                     console.warn(importRegionAck.message);
                 }
@@ -246,8 +249,11 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
             describe(`Export "${assertItem.exportRegion[idxRegion].file}"`, () => {
                 let exportRegionAck: CARTA.ExportRegionAck;
                 test(`EXPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ExportRegion, assertItem.exportRegion[idxRegion]);
-                    exportRegionAck = await Connection.receive(CARTA.ExportRegionAck) as CARTA.ExportRegionAck;
+                    await Connection.send(CARTA.ExportRegion, {
+                        ...assertItem.exportRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    exportRegionAck = (await Connection.streamUntil(type => type == CARTA.ExportRegionAck)).Responce[0] as CARTA.ExportRegionAck;
                 }, exportTimeout);
 
                 test(`EXPORT_REGION_ACK.success = ${exRegion.success}`, () => {
@@ -265,8 +271,11 @@ describe("DS9_REGION_IMPORT_EXPORT: Testing import/export of DS9 region format",
                 let importRegionAck: CARTA.ImportRegionAck;
                 let importRegionAckProperties: any;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.exportRegion[idxRegion]);
-                    importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.exportRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     if (importRegionAck.message != '') {
                         console.warn(importRegionAck.message);
                     }

--- a/src/test/DS9_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/DS9_REGION_IMPORT_INTERNAL.test.ts
@@ -239,8 +239,9 @@ describe("DS9_REGION_IMPORT_INTERNAL: Testing import of DS9 region files made wi
         let basePath: string;
         beforeAll(async () => {
             await Connection.send(CARTA.CloseFile, { fileId: -1, });
-            let fileAck = await Connection.openFile(assertItem.openFile);
-            basePath = fileAck.basePath;
+            await Connection.openFile(assertItem.openFile).then(()=>{
+                basePath = Connection.Property.basePath;
+            });
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -250,7 +251,7 @@ describe("DS9_REGION_IMPORT_INTERNAL: Testing import of DS9 region files made wi
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
                     await Connection.send(CARTA.ImportRegion, {
                         ...assertItem.importRegion[idxRegion],
-                        directory: basePath + "/" + regionSubdirectory,
+                        directory: basePath + regionSubdirectory,
                     });
                     importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)

--- a/src/test/DS9_REGION_IMPORT_INTERNAL.test.ts
+++ b/src/test/DS9_REGION_IMPORT_INTERNAL.test.ts
@@ -10,7 +10,7 @@ let connectTimeout = config.timeout.connection;
 let importTimeout = config.timeout.import;
 
 interface AssertItem {
-    register: CARTA.IRegisterViewer;
+    registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     setCursor: CARTA.ISetCursor;
     addTilesRequire: CARTA.IAddRequiredTiles;
@@ -20,7 +20,7 @@ interface AssertItem {
 };
 
 let assertItem: AssertItem = {
-    register: {
+    registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
     },
@@ -49,13 +49,13 @@ let assertItem: AssertItem = {
             {
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet1_world.reg",
             },
             {
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet1_pix.reg",
             },
         ],
@@ -232,15 +232,15 @@ describe("DS9_REGION_IMPORT_INTERNAL: Testing import of DS9 region files made wi
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
         await Connection.open();
-        await Connection.send(CARTA.RegisterViewer, assertItem.register);
-        await Connection.receive(CARTA.RegisterViewerAck);
+        await Connection.registerViewer(assertItem.registerViewer);
     }, connectTimeout);
 
     describe(`Go to "${testSubdirectory}" folder and open image "${assertItem.openFile.file}"`, () => {
+        let basePath: string;
         beforeAll(async () => {
-            await Connection.send(CARTA.CloseFile, { fileId: -1 });
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            await Connection.send(CARTA.CloseFile, { fileId: -1, });
+            let fileAck = await Connection.openFile(assertItem.openFile);
+            basePath = fileAck.basePath;
         });
 
         assertItem.importRegionAck.map((regionAck, idxRegion) => {
@@ -248,8 +248,11 @@ describe("DS9_REGION_IMPORT_INTERNAL: Testing import of DS9 region files made wi
                 let importRegionAck: CARTA.ImportRegionAck;
                 let importRegionAckProperties: any;
                 test(`IMPORT_REGION_ACK should return within ${importTimeout}ms`, async () => {
-                    await Connection.send(CARTA.ImportRegion, assertItem.importRegion[idxRegion]);
-                    importRegionAck = await Connection.receive(CARTA.ImportRegionAck) as CARTA.ImportRegionAck;
+                    await Connection.send(CARTA.ImportRegion, {
+                        ...assertItem.importRegion[idxRegion],
+                        directory: basePath + "/" + regionSubdirectory,
+                    });
+                    importRegionAck = (await Connection.streamUntil(type => type == CARTA.ImportRegionAck)).Responce[0] as CARTA.ImportRegionAck;
                     importRegionAckProperties = Object.keys(importRegionAck.regions)
                 }, importTimeout);
 

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
@@ -69,7 +69,7 @@ let assertItem: AssertItem = {
         mean: 18.742310241547514,//18.742310241547514 for socketdev; 18.743059611332498 for socketicd
         stdDev: 22.534722680160574,//22.534722680160574 for socketdev; 22.376087536494833 for socketicd
     },
-    precisionDigits: 4,
+    precisionDigits: 3,
 };
 
 describe("PER_CUBE_HISTOGRAM_HDF5: Testing calculations of the per-cube histogram of hdf5", () => {

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
@@ -69,7 +69,7 @@ let assertItem: AssertItem = {
         mean: 18.742310241547514,//18.742310241547514 for socketdev; 18.743059611332498 for socketicd
         stdDev: 22.534722680160574,//22.534722680160574 for socketdev; 22.376087536494833 for socketicd
     },
-    precisionDigits: 3,
+    precisionDigits: 4,
 };
 
 describe("PER_CUBE_HISTOGRAM_HDF5: Testing calculations of the per-cube histogram of hdf5", () => {

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -55,6 +55,6 @@
     "log": {
         "error": false,
         "warning": true,
-        "event": false
+        "event": true
     }
 }


### PR DESCRIPTION
From #196, we suppose to solve the failures on CI server at the moment by change the method of directory.

Some minor changes were done for the issues, which does not related to the directory issue.
e.g, the PER_CUBE_HISTOGRAM_HDF5