### PR TITLE
Turn off the log for websocket messages

### DIFF
--- a/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts
@@ -35,14 +35,14 @@ let assertItem: AssertItem = {
         [
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet2_pix.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,
             },
             {
                 contents: [],
-                directory: regionSubdirectory,
+                // directory: regionSubdirectory,
                 file: "M17_SWex_regionSet2_world.reg",
                 groupId: 0,
                 type: CARTA.FileType.DS9_REG,

--- a/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
+++ b/src/test/DS9_REGION_IMPORT_EXPORT.test.ts
@@ -59,7 +59,7 @@ let assertItem: AssertItem = {
     importRegion:
     {
         contents: [],
-        directory: regionSubdirectory,
+        // directory: regionSubdirectory,
         file: "M17_SWex_testRegions_pix.reg",
         groupId: 0,
         type: CARTA.FileType.DS9_REG,

--- a/src/test/config.json
+++ b/src/test/config.json
@@ -55,6 +55,6 @@
     "log": {
         "error": false,
         "warning": true,
-        "event": true
+        "event": false
     }
 }


### PR DESCRIPTION
Form #196, turn of the log for messages of ICD, which is only for monitoring the error condition.

Please use `squash and merge` as finalizing this PR, thanks.