### PR TITLE
Mylin/update spectral

### DIFF
--- a/src/test/SPECTRAL_LINE_QUERY.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY.test.ts
@@ -109,10 +109,10 @@ let assertItem: AssertItem = {
         },
         {
             success: true,
-            dataSize: 203,
+            dataSize: 204,
             lengthOfheaders: 19,
             speciesOfline: "Carbon Monoxide",
-            speciesOflineIndex: 200,
+            speciesOflineIndex: 201,
             freqSpeciesOfline: "220398.68420",
         },
     ],

--- a/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
@@ -108,12 +108,19 @@ assertItem.setSpectralLineReq.map((request, index) => {
                 }
             });
 
-            test(`(Step 3)Check the information of the first and the last molecular species`,async()=>{
+            test(`(Step 3)Check the information of two molecular species (one is near the 1st another is near the last)`,async()=>{
                 if (response2 != undefined && response2.dataSize === assertItem.SpectraLineResponse[index].dataSize) {
-                    expect(response2.spectralLineData[0].stringData[assertItem.SpectraLineResponse[index].speciesOflineIndex1st]).toEqual(assertItem.SpectraLineResponse[index].speciesOfline1st);
-                    expect(response2.spectralLineData[2].stringData[assertItem.SpectraLineResponse[index].speciesOflineIndex1st]).toEqual(assertItem.SpectraLineResponse[index].freqSpeciesOfline1st);
-                    expect(response2.spectralLineData[0].stringData[assertItem.SpectraLineResponse[index].speciesOflineIndexLast]).toEqual(assertItem.SpectraLineResponse[index].speciesOflineLast);
-                    expect(response2.spectralLineData[2].stringData[assertItem.SpectraLineResponse[index].speciesOflineIndexLast]).toEqual(assertItem.SpectraLineResponse[index].freqSpeciesOflineLast);
+                    // check at least two molecules freq inside a returned array
+                    expect(response2.spectralLineData[2].stringData).toEqual(expect.arrayContaining([assertItem.SpectraLineResponse[index].freqSpeciesOfline1st]));
+                    expect(response2.spectralLineData[2].stringData).toEqual(expect.arrayContaining([assertItem.SpectraLineResponse[index].freqSpeciesOflineLast]));
+                    // find the index of these two molecules freq
+                    const is1st = (element) => element ===  assertItem.SpectraLineResponse[index].freqSpeciesOfline1st;
+                    let tar1Index = response2.spectralLineData[2].stringData.findIndex(is1st);
+                    const islast = (element) => element ===  assertItem.SpectraLineResponse[index].freqSpeciesOflineLast;
+                    let tarlastIndex = response2.spectralLineData[2].stringData.findIndex(islast);
+                    // matching these two molecules' name
+                    expect(response2.spectralLineData[0].stringData[tar1Index]).toMatch(assertItem.SpectraLineResponse[index].speciesOfline1st)
+                    expect(response2.spectralLineData[0].stringData[tarlastIndex]).toMatch(assertItem.SpectraLineResponse[index].speciesOflineLast)
                 } else {
                     console.warn("Does not receive proper SpectralLineResponse")
                 };

--- a/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
@@ -45,13 +45,13 @@ let assertItem: AssertItem = {
     SpectraLineResponse: [
         {
             success: true,
-            dataSize: 75686,
+            dataSize: 75718,
             lengthOfheaders: 19,
             speciesOfline1st: "HOCH2CN",
             speciesOflineIndex1st: 0,
             freqSpeciesOfline1st: "420000.32970",
             speciesOflineLast: "CH2CDCN",
-            speciesOflineIndexLast: 75685,
+            speciesOflineIndexLast: 75717,
             freqSpeciesOflineLast: "439999.26740",
         },
         {
@@ -61,9 +61,9 @@ let assertItem: AssertItem = {
             speciesOfline1st: "HOCH2CN",
             speciesOflineIndex1st: 0,
             freqSpeciesOfline1st: "420000.32970",
-            speciesOflineLast: "NH2CH2CH2OHv26=1",
+            speciesOflineLast: "HNO3v5=1/v9=2",
             speciesOflineIndexLast: 99999,
-            freqSpeciesOflineLast: "430886.07520",
+            freqSpeciesOflineLast: "430883.75780",
         },
     ],
 };

--- a/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
@@ -61,9 +61,9 @@ let assertItem: AssertItem = {
             speciesOfline1st: "HOCH2CN",
             speciesOflineIndex1st: 0,
             freqSpeciesOfline1st: "420000.32970",
-            speciesOflineLast: "HNO3v5=1/v9=2",
+            speciesOflineLast: "c-H2COCH2",
             speciesOflineIndexLast: 99999,
-            freqSpeciesOflineLast: "430883.75780",
+            freqSpeciesOflineLast: "430883.86380",
         },
     ],
 };


### PR DESCRIPTION
Because the splatalogue datebase has an update.
The total number of query has been change (looks like they add more molecular lines into the database).

I also improve the matching algorithm SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts.