### PR TITLE
Mylin/improve spectral line query

### DIFF
--- a/src/test/SPECTRAL_LINE_QUERY.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY.test.ts
@@ -90,29 +90,29 @@ let assertItem: AssertItem = {
     },
     setSpectralLineReq: [
         {
-            frequencyRange: { min: 230500, max: 230600 },
+            frequencyRange: { min: 230537, max: 230539 },
             lineIntensityLowerLimit: -10,
         },
         {
-            frequencyRange: { min: 220350, max: 220400 },
+            frequencyRange: { min: 220398, max: 220399 },
             lineIntensityLowerLimit: -5,
         },
     ],
     SpectraLineResponse: [
         {
             success: true,
-            dataSize: 919,
+            dataSize: 26,
             lengthOfheaders: 19,
             speciesOfline: "COv=0",
-            speciesOflineIndex: 351,
+            speciesOflineIndex: 18,
             freqSpeciesOfline: "230538.00000",
         },
         {
             success: true,
-            dataSize: 204,
+            dataSize: 8,
             lengthOfheaders: 19,
             speciesOfline: "Carbon Monoxide",
-            speciesOflineIndex: 201,
+            speciesOflineIndex: 6,
             freqSpeciesOfline: "220398.68420",
         },
     ],

--- a/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
+++ b/src/test/SPECTRAL_LINE_QUERY_WIDE_FREQ.test.ts
@@ -61,9 +61,9 @@ let assertItem: AssertItem = {
             speciesOfline1st: "HOCH2CN",
             speciesOflineIndex1st: 0,
             freqSpeciesOfline1st: "420000.32970",
-            speciesOflineLast: "c-H2COCH2",
-            speciesOflineIndexLast: 99999,
-            freqSpeciesOflineLast: "430883.86380",
+            speciesOflineLast: "HNO3",
+            speciesOflineIndexLast: 99926,
+            freqSpeciesOflineLast: "430878.88820",
         },
     ],
 };


### PR DESCRIPTION
Improve spectral line query tests based on Jason's yesterday suggestion.
I narrow down the query range.
In addition, minor correction for searching wide freq range query.