### PR TITLE
Change the condition of receiving moment message

### DIFF
--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -61,7 +61,7 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
         let MomentResponse: CARTA.MomentResponse;
         test(`Request a moment progress but cancel after receiving 5 MomentProgress`, async () => {
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            ack = await Connection.streamUntil((type, data, ack) => ack.MomentProgress.length==5);
+            ack = await Connection.streamUntil((type, data, ack) => ack.MomentProgress.length == 5);
             FileId = ack.RegionHistogramData.map(data => data.fileId);
             await Connection.send(CARTA.StopMomentCalc, { fileId: 0 });
             MomentResponse = await Connection.receive(CARTA.MomentResponse);
@@ -100,7 +100,9 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
                 ...assertItem.momentRequest,
                 moments: [12],
             });
-            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            ack = await Connection.streamUntil(
+                type => type == CARTA.MomentResponse
+            );
             expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
 

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -92,7 +92,11 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            ack = await Connection.streamUntil(
+                (type, data, ack) =>
+                    ack.RegionHistogramData.length == assertItem.momentRequest.moments.length &&
+                    ack.MomentResponse.length > 0
+            );
             FileId = ack.RegionHistogramData.map(data => data.fileId);
             expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
@@ -163,7 +167,7 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
                     compressionType: CARTA.CompressionType.NONE,
                     compressionQuality: 0,
                 });
-                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false).then(ack => {
+                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync && data.endSync).then(ack => {
                     RasterTileSync.push(...ack.RasterTileSync.slice(-1));
                     RasterTileData.push(...ack.RasterTileData);
                 });

--- a/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
+++ b/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
@@ -79,7 +79,11 @@ describe("MOMENTS_GENERATOR_EXCEPTION: Testing moments generator for exception",
         let ack: AckStream;
         test(`Receive a series of moment progress & MomentProgress.progress < 1`, async () => {
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest[1]);
-            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            ack = await Connection.streamUntil(
+                (type, data, ack) =>
+                    ack.RegionHistogramData.length == assertItem.momentRequest[1].moments.length &&
+                    ack.MomentResponse.length > 0
+            );
             FileId = ack.RegionHistogramData.map(data => data.fileId);
             expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
@@ -112,7 +116,7 @@ describe("MOMENTS_GENERATOR_EXCEPTION: Testing moments generator for exception",
                 compressionType: CARTA.CompressionType.ZFP,
                 compressionQuality: 11,
             });
-            await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+            await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync && data.endSync);
         }, readFileTimeout * FileId.length);
 
         test(`Receive SpatialProfileData`, async () => {

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -92,7 +92,11 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            ack = await Connection.streamUntil(
+                (type, data, ack) =>
+                    ack.RegionHistogramData.length == assertItem.momentRequest.moments.length &&
+                    ack.MomentResponse.length > 0
+            );
             FileId = ack.RegionHistogramData.map(data => data.fileId);
             expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
@@ -163,7 +167,7 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
                     compressionType: CARTA.CompressionType.NONE,
                     compressionQuality: 0,
                 });
-                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false).then(ack => {
+                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync && data.endSync).then(ack => {
                     RasterTileSync.push(...ack.RasterTileSync.slice(-1));
                     RasterTileData.push(...ack.RasterTileData);
                 });

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client,AckStream } from "./CLIENT";
+import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -92,7 +92,11 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
-            ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
+            ack = await Connection.streamUntil(
+                (type, data, ack) =>
+                    ack.RegionHistogramData.length == assertItem.momentRequest.moments.length &&
+                    ack.MomentResponse.length > 0
+            );
             FileId = ack.RegionHistogramData.map(data => data.fileId);
             expect(ack.MomentProgress.length).toBeGreaterThan(0);
         }, momentTimeout);
@@ -163,7 +167,7 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
                     compressionType: CARTA.CompressionType.NONE,
                     compressionQuality: 0,
                 });
-                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false).then(ack => {
+                await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync && data.endSync).then(ack => {
                     RasterTileSync.push(...ack.RasterTileSync.slice(-1));
                     RasterTileData.push(...ack.RasterTileData);
                 });


### PR DESCRIPTION
In case the message RegionHistogramData are not returned as early as our expected, may return after MomentResponse.
For issue #214, change the condition until being received 13 RegionHistogramData.