### PR TITLE
revert package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
         "isomorphic-ws": "^4.0.1",
         "pidusage": "^2.0.21",
         "procfs-stats": "^1.0.2",
-        "react-scripts": "^4.0.2",
-        "ws": "^7.4.4",
+        "react-scripts": "^3.4.4",
+        "ws": "^7.4.2",
         "zstd-codec": "^0.1.2"
     },
     "scripts": {
         "test": "react-scripts test --env=node --maxWorkers=1 --verbose --no-cache --forceExit"
     },
     "devDependencies": {
-        "@types/jest": "^26.0.20",
-        "@types/node": "^12.20.1",
+        "@types/jest": "^23.3.14",
+        "@types/node": "^10.17.51",
         "protobufjs": "6.9.0",
-        "typescript": "^4.1.5"
+        "typescript": "^3.9.7"
     }
 }


### PR DESCRIPTION
Because the console.log may also print out with weird unexpected format.
Similar situation can be found in [here](https://github.com/puppeteer/puppeteer/issues/6280)
We decide to revert package version.