### PR TITLE
Increase tolerance of testing moment generator

### DIFF
--- a/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CANCEL.test.ts
@@ -1,5 +1,5 @@
 import { CARTA } from "carta-protobuf";
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 const WebSocket = require('isomorphic-ws');
 
@@ -60,6 +60,7 @@ describe("MOMENTS_GENERATOR_CANCEL: Testing to cancel a moment generator for an 
         let ack: AckStream;
         let MomentResponse: CARTA.MomentResponse;
         test(`Request a moment progress but cancel after receiving 5 MomentProgress`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
             ack = await Connection.streamUntil((type, data, ack) => ack.MomentProgress.length == 5);
             FileId = ack.RegionHistogramData.map(data => data.fileId);

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -1,6 +1,6 @@
 import { CARTA } from "carta-protobuf";
 
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -92,6 +92,7 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
     describe(`Moment generator`, () => {
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
             await Connection.streamUntil(
                 (type, data, ack) =>

--- a/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
+++ b/src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts
@@ -1,6 +1,5 @@
 import { CARTA } from "carta-protobuf";
-
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 const WebSocket = require('isomorphic-ws');
 
@@ -69,6 +68,7 @@ describe("MOMENTS_GENERATOR_EXCEPTION: Testing moments generator for exception",
             await Connection.openFile(assertItem.openFile);
         }, readFileTimeout);
         test(`Request 3 moment images`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest[0]);
             await Connection.streamUntil(type => type == CARTA.MomentResponse);
         }, momentTimeout);
@@ -78,6 +78,7 @@ describe("MOMENTS_GENERATOR_EXCEPTION: Testing moments generator for exception",
     describe(`Moment generator again`, () => {
         let ack: AckStream;
         test(`Receive a series of moment progress & MomentProgress.progress < 1`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest[1]);
             ack = await Connection.streamUntil(
                 (type, data, ack) =>

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -1,6 +1,5 @@
 import { CARTA } from "carta-protobuf";
-
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -92,6 +91,7 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
     describe(`Moment generator`, () => {
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
             await Connection.streamUntil(
                 (type, data, ack) =>

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -1,6 +1,5 @@
 import { CARTA } from "carta-protobuf";
-
-import { Client, AckStream } from "./CLIENT";
+import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 
 let testServerUrl = config.serverURL;
@@ -92,6 +91,7 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
     describe(`Moment generator`, () => {
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
             await Connection.streamUntil(
                 (type, data, ack) =>

--- a/src/test/MOMENTS_GENERATOR_SAVE.test.ts
+++ b/src/test/MOMENTS_GENERATOR_SAVE.test.ts
@@ -1,5 +1,4 @@
 import { CARTA } from "carta-protobuf";
-
 import { Client, AckStream, Wait } from "./CLIENT";
 import config from "./config.json";
 
@@ -79,8 +78,7 @@ describe("MOMENTS_GENERATOR_SAVE: Testing moments generator for saving resultant
 
     describe(`Preparation`, () => {
         test(`Open image`, async () => {
-            await Connection.send(CARTA.OpenFile, assertItem.openFile);
-            await Connection.stream(2);
+            await Connection.openFile(assertItem.openFile);
         }, readFileTimeout);
 
     });
@@ -89,6 +87,7 @@ describe("MOMENTS_GENERATOR_SAVE: Testing moments generator for saving resultant
     describe(`Moment generator`, () => {
         let ack: AckStream;
         test(`Receive a series of moment progress`, async () => {
+            await Wait(200);
             await Connection.send(CARTA.MomentRequest, assertItem.momentRequest);
             ack = await Connection.streamUntil(type => type == CARTA.MomentResponse);
             FileId = ack.RegionHistogramData.map(data => data.fileId);


### PR DESCRIPTION
### Issue & solution
The testing for moment generator could be failed occasionally because the backend might not able handle the command of moment too soon just after finishing an opening file task. We provide a workaround to bypass this situation, that is to insert a waiting before requesting a moment generator.

### Test
The implement of this code was tested on both native Ubuntu and a docker image. There two testing, which repeated sending requests 200 times to a single backend, are run in parallel. The outcome has no failure.

**Note**
This situation is similar to the case of animator, which also needs a waiting duration before a request to avoid any failure.