### PR TITLE
Mylin/#270 region statistics update v24

### DIFF
--- a/src/test/ANIMATOR_DATA_STREAM.test.ts
+++ b/src/test/ANIMATOR_DATA_STREAM.test.ts
@@ -44,15 +44,19 @@ let assertItem: AssertItem = {
     stats: {
         fileId: 0,
         regionId: -1,
-        stats: [
-            CARTA.StatsType.NumPixels,
-            CARTA.StatsType.Sum,
-            CARTA.StatsType.Mean,
-            CARTA.StatsType.RMS,
-            CARTA.StatsType.Sigma,
-            CARTA.StatsType.SumSq,
-            CARTA.StatsType.Min,
-            CARTA.StatsType.Max
+        statsConfigs:[
+            {coordinate:"z", statsTypes:[
+                CARTA.StatsType.NumPixels,
+                CARTA.StatsType.Sum,
+                CARTA.StatsType.FluxDensity,
+                CARTA.StatsType.Mean,
+                CARTA.StatsType.RMS,
+                CARTA.StatsType.Sigma,
+                CARTA.StatsType.SumSq,
+                CARTA.StatsType.Min,
+                CARTA.StatsType.Max,
+                CARTA.StatsType.Extrema
+            ]}
         ],
     },
     histogram: {

--- a/src/test/ANIMATOR_NAVIGATION.test.ts
+++ b/src/test/ANIMATOR_NAVIGATION.test.ts
@@ -124,14 +124,16 @@ let assertItem: AssertItem = {
             stokes: 1,
             regionId: -1,
             progress: 1,
-            histograms: [{ channel: 2 }],
+            histograms: {},
+            channel: 2 ,
         },
         {
             fileId: 1,
             stokes: 0,
             regionId: -1,
             progress: 1,
-            histograms: [{ channel: 12 }],
+            histograms: {},
+            channel: 12 ,
         },
         {},
         {},
@@ -141,7 +143,8 @@ let assertItem: AssertItem = {
             stokes: 0,
             regionId: -1,
             progress: 1,
-            histograms: [{ channel: 0 }],
+            histograms: {},
+            channel: 0 
         },
     ],
     rasterTileDatas: [
@@ -233,8 +236,8 @@ describe("ANIMATOR_NAVIGATION: Testing using animator to see different frames/ch
                         expect(ack.RegionHistogramData[0].progress).toEqual(assertItem.regionHistogramDatas[index].progress);
                     });
 
-                    test(`REGION_HISTOGRAM_DATA.histograms.channel = ${assertItem.regionHistogramDatas[index].histograms[0].channel}`, () => {
-                        expect(ack.RegionHistogramData[0].histograms[0].channel).toEqual(assertItem.regionHistogramDatas[index].histograms[0].channel);
+                    test(`REGION_HISTOGRAM_DATA.histograms.channel = ${assertItem.regionHistogramDatas[index].channel}`, () => {
+                        expect(ack.RegionHistogramData[0].channel).toEqual(assertItem.regionHistogramDatas[index].channel);
                     });
 
                     test(`RASTER_IMAGE_DATA should arrive within ${changeChannelTimeout} ms.`, async () => {

--- a/src/test/MATCH_STATS.test.ts
+++ b/src/test/MATCH_STATS.test.ts
@@ -91,44 +91,148 @@ let assertItem: AssertItem = {
             {
                 fileId: 100,
                 regionId: 1,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 100,
                 regionId: 2,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 100,
                 regionId: 3,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 100,
                 regionId: 4,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
         ],
         [
             {
                 fileId: 101,
                 regionId: 1,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 101,
                 regionId: 2,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 101,
                 regionId: 3,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
             {
                 fileId: 101,
                 regionId: 4,
-                stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
+                statsConfigs:[
+                    {coordinate:"z", statsTypes:[
+                        CARTA.StatsType.NumPixels,
+                        CARTA.StatsType.Sum,
+                        CARTA.StatsType.FluxDensity,
+                        CARTA.StatsType.Mean,
+                        CARTA.StatsType.RMS,
+                        CARTA.StatsType.Sigma,
+                        CARTA.StatsType.SumSq,
+                        CARTA.StatsType.Min,
+                        CARTA.StatsType.Max,
+                    ]}
+                ],
+                // stats: [0, 2, 3, 4, 5, 6, 7, 8, 9],
             },
         ],
     ]
@@ -189,7 +293,7 @@ describe("MATCH_STATS: Testing region stats with spatially and spectrally matche
             //     console.log(RegionStatsData.find(data => data.fileId == assertItem.openFile[0].fileId && data.regionId == region.regionId).statistics);
             //     console.log(RegionStatsData.find(data => data.fileId == assertItem.openFile[1].fileId && data.regionId == region.regionId).statistics);
             // });
-            for (const [statsIdx, statsType] of assertItem.setStatsRequirements[0][regionIdx].stats.entries()) {
+            for (const [statsIdx, statsType] of assertItem.setStatsRequirements[0][regionIdx].statsConfigs[0].statsTypes.entries()) {
                 test(`Assert the ${CARTA.StatsType[statsType]} of region ${region.regionId} for first image equal to that for the second image`, () => {
                     const left = RegionStatsData.find(data => data.fileId == assertItem.openFile[0].fileId && data.regionId == region.regionId).statistics.find(data => data.statsType == statsType).value;
                     const right = RegionStatsData.find(data => data.fileId == assertItem.openFile[1].fileId && data.regionId == region.regionId).statistics.find(data => data.statsType == statsType).value;

--- a/src/test/PER_CUBE_HISTOGRAM.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM.test.ts
@@ -57,14 +57,12 @@ let assertItem: AssertItem = {
     },
     regionHistogramData: {
         regionId: -2,
-        histograms: [
-            {
-                channel: -2,
-                numBins: 2775,
-                binWidth: 0.7235205769538879,
-                firstBinCenter: -1773.2998046875,
-            },
-        ],
+        channel: -2,
+        histograms: {
+            numBins: 2775,
+            binWidth: 0.7235205769538879,
+            firstBinCenter: -1773.2998046875,
+        },
         lengthOfHistogramBins: 2775,
         binValues: [{ index: 2500, value: 9359604 },],
         mean: 18.742310255027036,
@@ -121,11 +119,11 @@ describe("PER_CUBE_HISTOGRAM: Testing calculations of the per-cube histogram", (
                     RegionHistogramData = ack.RegionHistogramData.slice(-1)[0];
                     ReceiveProgress = RegionHistogramData.progress;
                     expect(ReceiveProgress).toBeGreaterThanOrEqual(0.5);
-                    expect(RegionHistogramData.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
-                    expect(RegionHistogramData.histograms[0].channel).toEqual(assertItem.regionHistogramData.histograms[0].channel);
-                    expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
+                    expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                    expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                    expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
                     expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
                 }, cubeHistogramTimeout);
 
@@ -134,14 +132,14 @@ describe("PER_CUBE_HISTOGRAM: Testing calculations of the per-cube histogram", (
                     RegionHistogramData = ack.RegionHistogramData.slice(-1)[0];
                     ReceiveProgress = RegionHistogramData.progress;
                     expect(ReceiveProgress).toEqual(1);
-                    expect(RegionHistogramData.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
-                    expect(RegionHistogramData.histograms[0].bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
-                    expect(RegionHistogramData.histograms[0].channel).toEqual(assertItem.regionHistogramData.histograms[0].channel);
-                    expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
-                    expect(RegionHistogramData.histograms[0].mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
-                    expect(RegionHistogramData.histograms[0].stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                    expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                    expect(RegionHistogramData.histograms.bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                    expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                    expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                    expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                    expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
                     expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
                 }, cubeHistogramTimeout);
             });

--- a/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts
@@ -65,14 +65,13 @@ let assertItem: AssertItem = {
     },
     regionHistogramData: {
         regionId: -2,
-        histograms: [
-            {
-                channel: -2,
-                numBins: 2775,
-                binWidth: 0.7235205769538879,
-                firstBinCenter: -1773.2998046875,
-            },
-        ],
+        channel: -2,
+        histograms: 
+        {
+            numBins: 2775,
+            binWidth: 0.7235205769538879,
+            firstBinCenter: -1773.2998046875,
+        },
         lengthOfHistogramBins: 2775,
         binValues: [{ index: 2500, value: 9359604 },],
         mean: 18.742310255027036,
@@ -149,14 +148,14 @@ describe("PER_CUBE_HISTOGRAM_CANCELLATION: Testing calculations of the per-cube 
                     RegionHistogramData = ack.RegionHistogramData.slice(-1)[0];
                     ReceiveProgress = RegionHistogramData.progress;
                     expect(ReceiveProgress).toEqual(1);
-                    expect(RegionHistogramData.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
-                    expect(RegionHistogramData.histograms[0].bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
-                    expect(RegionHistogramData.histograms[0].channel).toEqual(assertItem.regionHistogramData.histograms[0].channel);
-                    expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
-                    expect(RegionHistogramData.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
-                    expect(RegionHistogramData.histograms[0].mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
-                    expect(RegionHistogramData.histograms[0].stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+                    expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+                    expect(RegionHistogramData.histograms.bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+                    expect(RegionHistogramData.channel).toEqual(assertItem.regionHistogramData.channel);
+                    expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
+                    expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
+                    expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+                    expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
                     expect(RegionHistogramData.regionId).toEqual(assertItem.regionHistogramData.regionId);
                 }, cubeHistogramTimeout);
             });

--- a/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
+++ b/src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts
@@ -8,7 +8,7 @@ let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
 let readFileTimeout = config.timeout.readFile;
-let regionTimeout = config.timeout.region;
+let cubeHistogramTimeout = config.timeout.cubeHistogram;
 
 interface IRegionHistogramDataExt extends CARTA.IRegionHistogramData {
     lengthOfHistogramBins: number;
@@ -56,14 +56,13 @@ let assertItem: AssertItem = {
     },
     regionHistogramData: {
         regionId: -2,
-        histograms: [
-            {
-                channel: -2,
-                numBins: 2775,
-                binWidth: 0.7235205573004645,
-                firstBinCenter: -1773.2998608150997,
-            },
-        ],
+        channel: -2,
+        histograms: 
+        {
+            numBins: 2775,
+            binWidth: 0.7235205573004645,
+            firstBinCenter: -1773.2998046875,
+        },
         lengthOfHistogramBins: 2775,
         binValues: [{ index: 2500, value: 9359604 },],
         mean: 18.742310241547514,//18.742310241547514 for socketdev; 18.743059611332498 for socketicd
@@ -95,43 +94,43 @@ describe("PER_CUBE_HISTOGRAM_HDF5: Testing calculations of the per-cube histogra
     describe(`Request histogram requirements:`, () => {
         let ReceiveProgress: number;
         let RegionHistogramData: CARTA.RegionHistogramData;
-        test(`REGION_HISTOGRAM_DATA should arrive completely within ${regionTimeout} ms:`, async () => {
+        test(`REGION_HISTOGRAM_DATA should arrive completely within ${cubeHistogramTimeout} ms:`, async () => {
             await Connection.send(CARTA.SetHistogramRequirements, assertItem.setHistogramRequirements);
-            let ack = await Connection.streamUntil((type, data) => type == CARTA.RegionHistogramData && data.progress > 0.5);
+            let ack = await Connection.streamUntil((type, data) => type == CARTA.RegionHistogramData && data.progress == 1.0);
             RegionHistogramData = ack.RegionHistogramData.slice(-1)[0];
             ReceiveProgress = RegionHistogramData.progress;
-        }, regionTimeout);
+        }, cubeHistogramTimeout);
 
         test(`Assert REGION_HISTOGRAM_DATA.progress == 1`, () => {
             expect(ReceiveProgress).toBe(1);
         });
 
-        test(`Assert REGION_HISTOGRAM_DATA.histograms.bin_width = ${assertItem.regionHistogramData.histograms[0].binWidth}`, () => {
-            expect(RegionHistogramData.histograms[0].binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms[0].binWidth, assertItem.precisionDigits);
+        test(`Assert REGION_HISTOGRAM_DATA.histograms.bin_width = ${assertItem.regionHistogramData.histograms.binWidth}`, () => {
+            expect(RegionHistogramData.histograms.binWidth).toBeCloseTo(assertItem.regionHistogramData.histograms.binWidth, assertItem.precisionDigits);
         });
 
         test(`Assert len(REGION_HISTOGRAM_DATA.histograms.bins) = ${assertItem.regionHistogramData.lengthOfHistogramBins}`, () => {
-            expect(RegionHistogramData.histograms[0].bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
+            expect(RegionHistogramData.histograms.bins.length).toEqual(assertItem.regionHistogramData.lengthOfHistogramBins);
         });
 
         test(`Assert REGION_HISTOGRAM_DATA.histograms.bins[2500] = 9359604`, () => {
-            expect(RegionHistogramData.histograms[0].bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
+            expect(RegionHistogramData.histograms.bins[2500]).toEqual(assertItem.regionHistogramData.binValues[0].value);
         });
 
-        test(`Assert REGION_HISTOGRAM_DATA.histograms.firt_bin_center = ${assertItem.regionHistogramData.histograms[0].firstBinCenter}`, () => {
-            expect(RegionHistogramData.histograms[0].firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms[0].firstBinCenter, assertItem.precisionDigits);
+        test(`Assert REGION_HISTOGRAM_DATA.histograms.firt_bin_center = ${assertItem.regionHistogramData.histograms.firstBinCenter}`, () => {
+            expect(RegionHistogramData.histograms.firstBinCenter).toBeCloseTo(assertItem.regionHistogramData.histograms.firstBinCenter, assertItem.precisionDigits);
         });
 
-        test(`Assert REGION_HISTOGRAM_DATA.histograms.num_bins = ${assertItem.regionHistogramData.histograms[0].numBins}`, () => {
-            expect(RegionHistogramData.histograms[0].numBins).toEqual(assertItem.regionHistogramData.histograms[0].numBins);
+        test(`Assert REGION_HISTOGRAM_DATA.histograms.num_bins = ${assertItem.regionHistogramData.histograms.numBins}`, () => {
+            expect(RegionHistogramData.histograms.numBins).toEqual(assertItem.regionHistogramData.histograms.numBins);
         });
 
         test(`Assert REGION_HISTOGRAM_DATA.histograms.mean = ${assertItem.regionHistogramData.mean}`, () => {
-            expect(RegionHistogramData.histograms[0].mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
+            expect(RegionHistogramData.histograms.mean).toBeCloseTo(assertItem.regionHistogramData.mean, assertItem.precisionDigits)
         });
 
         test(`Assert REGION_HISTOGRAM_DATA.histograms.stdDev = ${assertItem.regionHistogramData.stdDev}`, () => {
-            expect(RegionHistogramData.histograms[0].stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
+            expect(RegionHistogramData.histograms.stdDev).toBeCloseTo(assertItem.regionHistogramData.stdDev, assertItem.precisionDigits)
         });
 
         test(`Assert REGION_HISTOGRAM_DATA.histograms.region_id = ${assertItem.regionHistogramData.regionId}`, () => {

--- a/src/test/REGION_STATISTICS_ELLIPSE.test.ts
+++ b/src/test/REGION_STATISTICS_ELLIPSE.test.ts
@@ -103,49 +103,55 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             regionId: 1,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: 2,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: 3,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
     ],

--- a/src/test/REGION_STATISTICS_POLYGON.test.ts
+++ b/src/test/REGION_STATISTICS_POLYGON.test.ts
@@ -145,98 +145,182 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             regionId: 1,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
         {
             fileId: 0,
             regionId: 2,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
         {
             fileId: 0,
             regionId: 3,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
         {
             fileId: 0,
             regionId: 4,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
         {
             fileId: 0,
             regionId: 5,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
         {
             fileId: 0,
             regionId: 6,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
+            // stats: [
+            //     CARTA.StatsType.NumPixels,
+            //     CARTA.StatsType.Sum,
+            //     CARTA.StatsType.FluxDensity,
+            //     CARTA.StatsType.Mean,
+            //     CARTA.StatsType.RMS,
+            //     CARTA.StatsType.Sigma,
+            //     CARTA.StatsType.SumSq,
+            //     CARTA.StatsType.Min,
+            //     CARTA.StatsType.Max,
+            //     CARTA.StatsType.Extrema
+            // ],
         },
     ],
     regionStatsData: [

--- a/src/test/REGION_STATISTICS_RECTANGLE.test.ts
+++ b/src/test/REGION_STATISTICS_RECTANGLE.test.ts
@@ -121,81 +121,91 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             regionId: 1,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: 2,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: 3,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: 4,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
         {
             fileId: 0,
             regionId: -1,
-            stats: [
-                CARTA.StatsType.NumPixels,
-                CARTA.StatsType.Sum,
-                CARTA.StatsType.FluxDensity,
-                CARTA.StatsType.Mean,
-                CARTA.StatsType.RMS,
-                CARTA.StatsType.Sigma,
-                CARTA.StatsType.SumSq,
-                CARTA.StatsType.Min,
-                CARTA.StatsType.Max,
-                CARTA.StatsType.Extrema
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.Sum,
+                    CARTA.StatsType.FluxDensity,
+                    CARTA.StatsType.Mean,
+                    CARTA.StatsType.RMS,
+                    CARTA.StatsType.Sigma,
+                    CARTA.StatsType.SumSq,
+                    CARTA.StatsType.Min,
+                    CARTA.StatsType.Max,
+                    CARTA.StatsType.Extrema
+                ]}
             ],
         },
     ],

--- a/src/test/RESUME_REGION.test.ts
+++ b/src/test/RESUME_REGION.test.ts
@@ -17,7 +17,6 @@ interface AssertItem {
 let assertItem: AssertItem = {
     register: {
         sessionId: 0,
-        apiKey: "",
         clientFeatureFlags: 5,
     },
     precisionDigits: 4,
@@ -68,12 +67,26 @@ let assertItem: AssertItem = {
         {
             fileId: 0,
             regionId: 1,
-            stats: [0, 1, 2,],
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.NanCount,
+                    CARTA.StatsType.Sum,
+                ]}
+            ],
+            // stats: [0, 1, 2,],
         },
         {
             fileId: 1,
             regionId: 2,
-            stats: [0, 1, 2,],
+            statsConfigs:[
+                {coordinate:"z", statsTypes:[
+                    CARTA.StatsType.NumPixels,
+                    CARTA.StatsType.NanCount,
+                    CARTA.StatsType.Sum,
+                ]}
+            ],
+            // stats: [0, 1, 2,],
         },
     ],
 }


### PR DESCRIPTION
Fixed #270 
I found Jenkins failed on moment related ICD tests, however they are all fine with
`HDF5_DISABLE_VERSION_CHECK=2 ./carta_backend /scratch/images  --port=4013 --debug_no_auth=true --no_http=true --verbosity=5 --log_performance=true --omp_threads=4` on acdc/mingyi

I have no idea why they failed on Jenkins...other ICD failure I can reproduce.