### PR TITLE
Mylin/#282 header history

### DIFF
--- a/src/test/FILEINFO_CASA.test.ts
+++ b/src/test/FILEINFO_CASA.test.ts
@@ -10,12 +10,16 @@ let listFileTimeout = config.timeout.listFile;
 let openFileTimeout = config.timeout.openFile;
 
 interface AssertItem {
+    headerCount: number;
+    headerHistoryCount: number;
     registerViewer: CARTA.IRegisterViewer;
     fileInfoRequest: CARTA.IFileInfoRequest;
     fileInfoResponse: CARTA.IFileInfoResponse;
 };
 
 let assertItem: AssertItem = {
+    headerCount: 1274,
+    headerHistoryCount: 1201,
     registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
@@ -409,8 +413,20 @@ describe("FILEINFO_CASA: Testing if info of an CASA image file is correctly deli
                 });
             });
 
-            test(`len(file_info_extended.header_entries)==${assertItem.fileInfoResponse.fileInfoExtended[''].headerEntries.length}`, () => {
-                expect(FileInfoResponse.fileInfoExtended[''].headerEntries.length).toEqual(assertItem.fileInfoResponse.fileInfoExtended[''].headerEntries.length)
+            test(`len(file_info_extended.header_entries)==${assertItem.headerCount}`, () => {
+                expect(FileInfoResponse.fileInfoExtended[''].headerEntries.length).toEqual(assertItem.headerCount);
+            });
+
+            test(`len(file_info_extended.header_entries) of "HISTORY" header ==${assertItem.headerHistoryCount}`, ()=> {
+                let count = 0;
+                FileInfoResponse.fileInfoExtended[''].headerEntries.find((f)=>{
+                    let fstring = String(f.name);
+                    let historyMatched = /HISTORY/;
+                    if (fstring.match(historyMatched)){
+                        count++;
+                    };
+                });
+                expect(count).toEqual(assertItem.headerHistoryCount);
             });
 
             test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {

--- a/src/test/FILEINFO_FITS.test.ts
+++ b/src/test/FILEINFO_FITS.test.ts
@@ -3,19 +3,21 @@ import { CARTA } from "carta-protobuf";
 import { Client } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL;
+let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let listFileTimeout = config.timeout.listFile;
 let openFileTimeout = config.timeout.openFile;
 
 interface AssertItem {
+    headerCount: number;
     registerViewer: CARTA.IRegisterViewer;
     fileInfoRequest: CARTA.IFileInfoRequest;
     fileInfoResponse: CARTA.IFileInfoResponse;
 };
 
 let assertItem: AssertItem = {
+    headerCount: 2389,
     registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
@@ -381,8 +383,23 @@ describe("FILEINFO_FITS: Testing if info of an FITS image file is correctly deli
                 });
             });
 
-            test(`len(file_info_extended.header_entries)==${assertItem.fileInfoResponse.fileInfoExtended['0'].headerEntries.length}`, () => {
-                expect(FileInfoResponse.fileInfoExtended['0'].headerEntries.length).toEqual(assertItem.fileInfoResponse.fileInfoExtended['0'].headerEntries.length)
+            test(`len(file_info_extended.header_entries)==${assertItem.headerCount}`, () => {
+                let count = 0;
+                let nonHCount = 0
+                console.log(FileInfoResponse.fileInfoExtended['0'].headerEntries);
+                FileInfoResponse.fileInfoExtended['0'].headerEntries.find((f)=>{
+                    let f2 = String(f.name);
+                    let matched = /HISTORY/;
+                    if (f2.match(matched)){
+                        count++
+                    } else {
+                        console.log(f2)
+                        nonHCount++
+                    }
+                });
+                console.log(count);
+                console.log(nonHCount);
+                expect(FileInfoResponse.fileInfoExtended['0'].headerEntries.length).toEqual(assertItem.headerCount);
             });
 
             test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {

--- a/src/test/FILEINFO_FITS.test.ts
+++ b/src/test/FILEINFO_FITS.test.ts
@@ -3,7 +3,7 @@ import { CARTA } from "carta-protobuf";
 import { Client } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL0;
+let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let listFileTimeout = config.timeout.listFile;
@@ -11,6 +11,7 @@ let openFileTimeout = config.timeout.openFile;
 
 interface AssertItem {
     headerCount: number;
+    headerHistoryCount: number;
     registerViewer: CARTA.IRegisterViewer;
     fileInfoRequest: CARTA.IFileInfoRequest;
     fileInfoResponse: CARTA.IFileInfoResponse;
@@ -18,6 +19,7 @@ interface AssertItem {
 
 let assertItem: AssertItem = {
     headerCount: 2389,
+    headerHistoryCount: 2315,
     registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
@@ -384,23 +386,20 @@ describe("FILEINFO_FITS: Testing if info of an FITS image file is correctly deli
             });
 
             test(`len(file_info_extended.header_entries)==${assertItem.headerCount}`, () => {
-                let count = 0;
-                let nonHCount = 0
-                console.log(FileInfoResponse.fileInfoExtended['0'].headerEntries);
-                FileInfoResponse.fileInfoExtended['0'].headerEntries.find((f)=>{
-                    let f2 = String(f.name);
-                    let matched = /HISTORY/;
-                    if (f2.match(matched)){
-                        count++
-                    } else {
-                        console.log(f2)
-                        nonHCount++
-                    }
-                });
-                console.log(count);
-                console.log(nonHCount);
                 expect(FileInfoResponse.fileInfoExtended['0'].headerEntries.length).toEqual(assertItem.headerCount);
             });
+
+            test(`len(file_info_extended.header_entries) of "HISTORY" header ==${assertItem.headerHistoryCount}`, ()=> {
+                let count = 0;
+                FileInfoResponse.fileInfoExtended['0'].headerEntries.find((f)=>{
+                    let fstring = String(f.name);
+                    let historyMatched = /HISTORY/;
+                    if (fstring.match(historyMatched)){
+                        count++;
+                    };
+                });
+                expect(count).toEqual(assertItem.headerHistoryCount);
+            })
 
             test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {
                 assertItem.fileInfoResponse.fileInfoExtended['0'].headerEntries.map((entry: CARTA.IHeaderEntry, index) => {

--- a/src/test/FILEINFO_FITS.test.ts
+++ b/src/test/FILEINFO_FITS.test.ts
@@ -399,7 +399,7 @@ describe("FILEINFO_FITS: Testing if info of an FITS image file is correctly deli
                     };
                 });
                 expect(count).toEqual(assertItem.headerHistoryCount);
-            })
+            });
 
             test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {
                 assertItem.fileInfoResponse.fileInfoExtended['0'].headerEntries.map((entry: CARTA.IHeaderEntry, index) => {

--- a/src/test/FILEINFO_FITS_MULTIHDU.test.ts
+++ b/src/test/FILEINFO_FITS_MULTIHDU.test.ts
@@ -10,6 +10,7 @@ let listFileTimeout = config.timeout.listFile;
 let openFileTimeout = config.timeout.openFile;
 
 interface AssertItem {
+    headerCount: number;
     registerViewer: CARTA.IRegisterViewer;
     fileInfoRequest: CARTA.IFileInfoRequest;
     fileInfoExtendedString: string[];
@@ -17,6 +18,7 @@ interface AssertItem {
 };
 
 let assertItem: AssertItem = {
+    headerCount: 53,
     registerViewer: {
         sessionId: 0,
         clientFeatureFlags: 5,
@@ -114,7 +116,7 @@ let assertItem: AssertItem = {
                         numericValue: 2000
                     },
                     {
-                        name: "CROTA",
+                        name: "CROTA2",
                         value: "0.000000000000E+00",
                         entryType: 1,
                         comment: " [] The Rotation angle"
@@ -211,7 +213,7 @@ let assertItem: AssertItem = {
                         numericValue: 2000
                     },
                     {
-                        name: "CROTA",
+                        name: "CROTA2",
                         value: "0.000000000000E+00",
                         entryType: 1,
                         comment: " [] The Rotation angle"
@@ -308,7 +310,7 @@ let assertItem: AssertItem = {
                         numericValue: 2000
                     },
                     {
-                        name: "CROTA",
+                        name: "CROTA2",
                         value: "0.000000000000E+00",
                         entryType: 1,
                         comment: " [] The Rotation angle"
@@ -377,7 +379,6 @@ describe("FILEINFO_FITS_MULTIHDU: Testing if info of an FITS image file is corre
 
             test(`FILE_INFO_RESPONSE.file_info.type = ${CARTA.FileType.FITS}`, () => {
                 expect(FileInfoResponse.fileInfo.type).toBe(assertItem.fileInfoResponse.fileInfo.type);
-                // console.log(FileInfoResponse.fileInfoExtended[assertItem.fileInfoExtendedString[0]])
             });
 
             assertItem.fileInfoExtendedString.map((input, index) => {
@@ -425,16 +426,24 @@ describe("FILEINFO_FITS_MULTIHDU: Testing if info of an FITS image file is corre
                         });
                     });
 
-                    test(`len(file_info_extended.header_entries)==${assertItem.fileInfoResponse.fileInfoExtended[input].headerEntries.length}`, () => {
-                        expect(FileInfoResponse.fileInfoExtended[input].headerEntries.length).toEqual(assertItem.fileInfoResponse.fileInfoExtended[input].headerEntries.length)
+                    test(`len(file_info_extended.header_entries)==${assertItem.headerCount}`, () => {
+                        expect(FileInfoResponse.fileInfoExtended[input].headerEntries.length).toEqual(assertItem.headerCount)
                     });
 
                     test(`assert FILE_INFO_RESPONSE.file_info_extended.header_entries`, () => {
+                        let FileInfoResponse_value = [];
+                        FileInfoResponse.fileInfoExtended[input].headerEntries.map((f) => {
+                            let keysNum = Object.keys(f).length;
+                            if (keysNum > 1) {
+                                FileInfoResponse_value.push(f)
+                            };
+                        });
+
                         assertItem.fileInfoResponse.fileInfoExtended[input].headerEntries.map((entry: CARTA.IHeaderEntry, index) => {
                             if (isNaN(parseFloat(entry.value))){
-                                expect(FileInfoResponse.fileInfoExtended[input].headerEntries.find(f => f.name == entry.name).value).toEqual(entry.value);
+                                expect(FileInfoResponse_value.find(f => f.name == entry.name).value).toEqual(entry.value);
                             } else {
-                                expect(parseFloat(FileInfoResponse.fileInfoExtended[input].headerEntries.find(f => f.name == entry.name).value)).toEqual(parseFloat(entry.value));
+                                expect(parseFloat(FileInfoResponse_value.find(f => f.name == entry.name).value)).toEqual(parseFloat(entry.value));
                             }
                         });
                     });

--- a/src/test/FILEINFO_HDF5.test.ts
+++ b/src/test/FILEINFO_HDF5.test.ts
@@ -43,6 +43,7 @@ let assertItem: AssertItem = {
                 stokesVals: [],
                 computedEntries: [
                     { name: "Name", value: "M17_SWex.hdf5" },
+                    { name: 'HDU', value: '0' },
                     { name: "Shape", value: "[640, 800, 25, 1]" },
                     {
                         name: "Number of channels",

--- a/src/test/FILEINFO_MIRIAD.test.ts
+++ b/src/test/FILEINFO_MIRIAD.test.ts
@@ -3,7 +3,7 @@ import { CARTA } from "carta-protobuf";
 import { Client } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL;
+let testServerUrl = config.serverURL0;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let listFileTimeout = config.timeout.listFile;
@@ -264,6 +264,10 @@ let assertItem: AssertItem = {
                         entryType: 2,
                         numericValue: 258,
                         comment: '1 LSR, 2 HEL, 3 OBS, +256 Radio'
+                    },
+                    {
+                        name: "COMMENT",
+                        comment: 'casacore non-standard usage: 4 LSD, 5 GEO, 6 SOU, 7 GAL'
                     },
                     { name: "TELESCOP", value: "ALMA" },
                     { name: "DATE-OBS", value: "2016-04-03T13:02:58.799982" },

--- a/src/test/FILEINFO_MIRIAD.test.ts
+++ b/src/test/FILEINFO_MIRIAD.test.ts
@@ -3,7 +3,7 @@ import { CARTA } from "carta-protobuf";
 import { Client } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL0;
+let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let listFileTimeout = config.timeout.listFile;

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -146,9 +146,9 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 73`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 654`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(73);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(654);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -146,9 +146,9 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 73`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 652`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(73);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(652);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -146,9 +146,9 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 78`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 79`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(78);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(79);
             });
         });
 


### PR DESCRIPTION
Fixed #282 
I modify the header check for COMMENT and HISTORY.
Now the `FILEINFO_FITS.test.ts`, `FILEINFO_CASA.test.ts`, and `FILEINFO_HDF5.test.ts` will check the header entries HISTORY length.

The header entries length in the moment related tests are also updated.
The tests have been test on almac MacOS and my local desktop Ubuntu 20.04.