### PR TITLE
Mylin/#285 multi spectral profile plot

### DIFF
--- a/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
@@ -69,7 +69,22 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
         test(`return RASTER_TILE_DATA(Stream) and check total length `, async()=>{
             await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[0]);
             ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
-            expect(ack.RasterTileData.length).toBe(assertItem.addTilesReq[0].tiles.length);
+            expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq[0].tiles.length);
+            expect(ack.RasterTileSync.length).toEqual(2);
+        })
+    });
+
+    describe(`Prepare the second images`, () => {
+        test(`Should open image ${assertItem.openFile[1].file}:`, async () => {
+            await Connection.openFile(assertItem.openFile[1]);
+        }, openFileTimeout);
+
+        let ack: AckStream;
+        test(`return RASTER_TILE_DATA(Stream) and check total length `, async()=>{
+            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq[1]);
+            ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+            expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq[1].tiles.length);
+            expect(ack.RasterTileSync.length).toEqual(2);
         })
     });
 

--- a/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
@@ -172,7 +172,7 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+describe("MULTI-SPECTRAL-PROFILE-IMAGE: Test plotting the multi-spectral profiles with two matched images", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);

--- a/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
@@ -1,0 +1,47 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+
+interface AssertItem {
+    precisionDigits: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+}
+let assertItem: AssertItem = {
+    precisionDigits: 4,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        fileId: 100,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+        
+};
+
+describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.registerViewer(assertItem.registerViewer);
+        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+    }, connectTimeout);
+
+    describe(`Prepare images`, () => {
+        test(`Should open image ${assertItem.openFile.file}:`, async () => {
+            await Connection.openFile(assertItem.openFile);
+        }, openFileTimeout);
+    });
+
+    afterAll(() => Connection.close());
+});

--- a/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-IMAGE.test.ts
@@ -20,7 +20,7 @@ interface AssertItem {
     setImageChannel: CARTA.ISetImageChannels[];
     setRegion: CARTA.ISetRegion;
     setSpectralRequirements: CARTA.ISetSpectralRequirements[];
-    ReturnSpectralProfileData: CARTA.ISpectralProfileIndexValue[];
+    ReturnSpectralProfileData: ISpectralProfileIndexValue[];
 }
 let assertItem: AssertItem = {
     precisionDigits: 7,

--- a/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
@@ -1,0 +1,204 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.QA;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+interface ISpectralProfileIndexValue {
+    index: number;
+    value: number;
+}
+interface AssertItem {
+    precisionDigits: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements[];
+    ReturnSpectralProfileData: ISpectralProfileIndexValue[];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 7,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HH211_IQU.fits",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+        
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [16777216, 16781312, 16777217, 16781313],
+    },
+    setRegion: {
+        fileId: 0,
+        regionId: -1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 520, y: 520 }, { x: 100, y: 100 }],
+            rotation: 0.0,
+        }
+    },
+    setSpectralRequirements: [
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "Qz",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                },
+                {
+                    coordinate: "Iz",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                },
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                },
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "Iz",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+    ],
+    ReturnSpectralProfileData: [
+        {
+            index: 0,
+            value: -0.0007642408502170499,
+        },
+        {
+            index: 100,
+            value: 0.014224687421439227,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+        {
+            index: 0,
+            value: 0.0062467408097798246,
+        },
+        {
+            index: 100,
+            value: 0.06037216936383088,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+        {
+            index: 0,
+            value: 0.0062001189561202924,
+        },
+        {
+            index: 100,
+            value: 0.05867533210175882,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+    ],
+};
+
+describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.registerViewer(assertItem.registerViewer);
+        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+    }, connectTimeout);
+
+    describe(`Prepare the images`, () => {
+        test(`Should open image ${assertItem.openFile.file}:`, async () => {
+            await Connection.openFile(assertItem.openFile);
+        }, openFileTimeout);
+
+        let ack: AckStream;
+        test(`return RASTER_TILE_DATA(Stream) and check total length `, async()=>{
+            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+            ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+            expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq.tiles.length);
+            expect(ack.RasterTileSync.length).toEqual(2);
+        })
+    });
+
+    describe(`Plot multi polarizations in one region in the spectral profiler:`,()=>{
+        test(`Set one Region in the images`, async()=>{
+            await Connection.send(CARTA.SetRegion,assertItem.setRegion);
+            let RegionResponse1 = await Connection.receive(CARTA.SetRegionAck);
+            expect(RegionResponse1.regionId).toEqual(1);
+        });
+
+        // test(`Plot two statistics in the spectral profiles and check the values`, async()=>{
+        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[0]);
+        //     let temp1 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+        //     let FirstStatisticsSpectralProfile = temp1.SpectralProfileData.slice(-1)[0];
+        //     expect(FirstStatisticsSpectralProfile.regionId).toEqual(1);
+        //     expect(FirstStatisticsSpectralProfile.progress).toEqual(1);
+        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[0].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[0].value,assertItem.precisionDigits);
+        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[1].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[1].value,assertItem.precisionDigits);
+        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[2].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[2].value,assertItem.precisionDigits);
+
+        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[1]);
+        //     let temp2 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+        //     let SecondStatisticsSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
+        //     expect(SecondStatisticsSpectralProfile.regionId).toEqual(1);
+        //     expect(SecondStatisticsSpectralProfile.progress).toEqual(1);
+        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
+        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
+        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
+        // });
+
+        // test(`Plot two statistics in the spectral profiles within one SetSpectralRequirement request and check the values`,async()=>{
+        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[2]);
+        //     let temp3 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+        //     let ThirdStatisticsSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
+        //     expect(ThirdStatisticsSpectralProfile.regionId).toEqual(1);
+        //     expect(ThirdStatisticsSpectralProfile.progress).toEqual(1);
+        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
+        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
+        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);
+        // });
+    });
+
+    afterAll(() => Connection.close());
+});

--- a/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
@@ -144,7 +144,7 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+describe("MULTI-SPECTRAL-PROFILE-POLARIZATION: Test plotting the multi-spectral profiles with setting multi polarizations in one region", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
@@ -180,6 +180,8 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let FirstPolarizationSpectralProfile = temp1.SpectralProfileData.slice(-1)[0];
             expect(FirstPolarizationSpectralProfile.regionId).toEqual(1);
             expect(FirstPolarizationSpectralProfile.progress).toEqual(1);
+            expect(FirstPolarizationSpectralProfile.profiles[0].coordinate).toEqual("Iz");
+            expect(FirstPolarizationSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.Mean);
             expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[0].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[0].value,assertItem.precisionDigits);
             expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[1].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[1].value,assertItem.precisionDigits);
             expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[2].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[2].value,assertItem.precisionDigits);
@@ -189,6 +191,8 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let SecondPolarizationSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
             expect(SecondPolarizationSpectralProfile.regionId).toEqual(1);
             expect(SecondPolarizationSpectralProfile.progress).toEqual(1);
+            expect(SecondPolarizationSpectralProfile.profiles[0].coordinate).toEqual("Qz");
+            expect(SecondPolarizationSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.Mean);
             expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
             expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
             expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
@@ -200,6 +204,8 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let ThirdPolarizationSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
             expect(ThirdPolarizationSpectralProfile.regionId).toEqual(1);
             expect(ThirdPolarizationSpectralProfile.progress).toEqual(1);
+            expect(ThirdPolarizationSpectralProfile.profiles[0].coordinate).toEqual("Uz");
+            expect(ThirdPolarizationSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.Mean);
             expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
             expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
             expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);

--- a/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-POLARIZATION.test.ts
@@ -2,7 +2,7 @@ import { CARTA } from "carta-protobuf";
 import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL0;
+let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.QA;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
@@ -37,7 +37,7 @@ let assertItem: AssertItem = {
         fileId: 0,
         compressionQuality: 11,
         compressionType: CARTA.CompressionType.ZFP,
-        tiles: [16777216, 16781312, 16777217, 16781313],
+        tiles: [33558529,33558528, 33554433,33554432,33562625,33558530,33562624,33554434,33562626],
     },
     setRegion: {
         fileId: 0,
@@ -54,7 +54,25 @@ let assertItem: AssertItem = {
             regionId: 1,
             spectralProfiles: [
                 {
-                    coordinate: "z",
+                    coordinate: "Iz",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "Iz",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                },
+                {
+                    coordinate: "Qz",
                     statsTypes: [
                         CARTA.StatsType.Mean,
                     ],
@@ -78,62 +96,50 @@ let assertItem: AssertItem = {
                     ],
                 },
                 {
-                    coordinate: "z",
+                    coordinate: "Uz",
                     statsTypes: [
                         CARTA.StatsType.Mean,
                     ],
                 },
             ],
         },
-        {
-            fileId: 0,
-            regionId: 1,
-            spectralProfiles: [
-                {
-                    coordinate: "Iz",
-                    statsTypes: [
-                        CARTA.StatsType.Mean,
-                    ],
-                }
-            ],
-        },
     ],
     ReturnSpectralProfileData: [
         {
             index: 0,
-            value: -0.0007642408502170499,
+            value: 0.0007088588552472904,
         },
         {
-            index: 100,
-            value: 0.014224687421439227,
+            index: 2,
+            value: 0.0012602472319775562,
         },
         {
-            index: 200,
-            value: 0.0,
-        },
-        {
-            index: 0,
-            value: 0.0062467408097798246,
-        },
-        {
-            index: 100,
-            value: 0.06037216936383088,
-        },
-        {
-            index: 200,
-            value: 0.0,
+            index: 4,
+            value: 0.0007855336842870678,
         },
         {
             index: 0,
-            value: 0.0062001189561202924,
+            value: -0.00012210526080733863,
         },
         {
-            index: 100,
-            value: 0.05867533210175882,
+            index: 2,
+            value: -0.000033854758947925195,
         },
         {
-            index: 200,
-            value: 0.0,
+            index: 4,
+            value: -0.000008830321254663674,
+        },
+        {
+            index: 0,
+            value: 0.000010325868837087967,
+        },
+        {
+            index: 2,
+            value: -0.0000024363279953331134,
+        },
+        {
+            index: 4,
+            value: 0.000031310824961024904,
         },
     ],
 };
@@ -168,36 +174,37 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             expect(RegionResponse1.regionId).toEqual(1);
         });
 
-        // test(`Plot two statistics in the spectral profiles and check the values`, async()=>{
-        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[0]);
-        //     let temp1 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
-        //     let FirstStatisticsSpectralProfile = temp1.SpectralProfileData.slice(-1)[0];
-        //     expect(FirstStatisticsSpectralProfile.regionId).toEqual(1);
-        //     expect(FirstStatisticsSpectralProfile.progress).toEqual(1);
-        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[0].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[0].value,assertItem.precisionDigits);
-        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[1].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[1].value,assertItem.precisionDigits);
-        //     expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[2].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[2].value,assertItem.precisionDigits);
+        test(`Plot two polarizations in the spectral profiles and check the values`, async()=>{
+            await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[0]);
+            let temp1 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+            let FirstPolarizationSpectralProfile = temp1.SpectralProfileData.slice(-1)[0];
+            expect(FirstPolarizationSpectralProfile.regionId).toEqual(1);
+            expect(FirstPolarizationSpectralProfile.progress).toEqual(1);
+            expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[0].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[0].value,assertItem.precisionDigits);
+            expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[1].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[1].value,assertItem.precisionDigits);
+            expect(FirstPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[2].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[2].value,assertItem.precisionDigits);
 
-        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[1]);
-        //     let temp2 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
-        //     let SecondStatisticsSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
-        //     expect(SecondStatisticsSpectralProfile.regionId).toEqual(1);
-        //     expect(SecondStatisticsSpectralProfile.progress).toEqual(1);
-        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
-        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
-        //     expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
-        // });
+            await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[1]);
+            let temp2 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+            let SecondPolarizationSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
+            expect(SecondPolarizationSpectralProfile.regionId).toEqual(1);
+            expect(SecondPolarizationSpectralProfile.progress).toEqual(1);
+            expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
+            expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
+            expect(SecondPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
+        });
 
-        // test(`Plot two statistics in the spectral profiles within one SetSpectralRequirement request and check the values`,async()=>{
-        //     await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[2]);
-        //     let temp3 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
-        //     let ThirdStatisticsSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
-        //     expect(ThirdStatisticsSpectralProfile.regionId).toEqual(1);
-        //     expect(ThirdStatisticsSpectralProfile.progress).toEqual(1);
-        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
-        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
-        //     expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);
-        // });
+        test(`Plot three polarizations in the spectral profiles within one SetSpectralRequirement request and check the values`,async()=>{
+            await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[2]);
+            let temp3 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+            let ThirdPolarizationSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
+            expect(ThirdPolarizationSpectralProfile.regionId).toEqual(1);
+            expect(ThirdPolarizationSpectralProfile.progress).toEqual(1);
+            expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
+            expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
+            expect(ThirdPolarizationSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);
+        
+        });
     });
 
     afterAll(() => Connection.close());

--- a/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
@@ -1,0 +1,74 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+interface ISpectralProfileIndexValue {
+    index: number;
+    value: number;
+}
+interface AssertItem {
+    precisionDigits: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setCursor: CARTA.ISetCursor;
+}
+let assertItem: AssertItem = {
+    precisionDigits: 7,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+            file: "HD163296_CO_2_1.fits",
+            fileId: 0,
+            hdu: "",
+            renderMode: CARTA.RenderMode.RASTER,
+        },
+        
+    addTilesReq: 
+        {
+            fileId: 0,
+            compressionQuality: 11,
+            compressionType: CARTA.CompressionType.ZFP,
+            tiles: [16777216, 16781312, 16777217, 16781313],
+        },
+    setCursor: 
+        {
+            fileId: 0,
+            point: { x: 216, y: 216 },
+    
+        }, 
+};
+
+describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.registerViewer(assertItem.registerViewer);
+        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+    }, connectTimeout);
+
+    describe(`Prepare the first images`, () => {
+        test(`Should open image ${assertItem.openFile.file}:`, async () => {
+            await Connection.openFile(assertItem.openFile);
+        }, openFileTimeout);
+
+        let ack: AckStream;
+        test(`return RASTER_TILE_DATA(Stream) and check total length `, async()=>{
+            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+            ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+            expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq.tiles.length);
+            expect(ack.RasterTileSync.length).toEqual(2);
+        })
+    });
+
+
+    afterAll(() => Connection.close());
+});

--- a/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
@@ -43,7 +43,7 @@ let assertItem: AssertItem = {
             regionId: -1,
             regionInfo: {
                 regionType: CARTA.RegionType.RECTANGLE,
-                controlPoints: [{ x: 213, y: 277 }, { x: 100, y: 100 }],
+                controlPoints: [{ x: 210, y: 220 }, { x: 50, y: 50 }],
                 rotation: 0.0,
             }
         },
@@ -52,7 +52,7 @@ let assertItem: AssertItem = {
             regionId: -1,
             regionInfo: {
                 regionType: CARTA.RegionType.RECTANGLE,
-                controlPoints: [{ x: 213, y: 277 }, { x: 100, y: 100 }],
+                controlPoints: [{ x: 150, y: 170 }, { x: 35, y: 35 }],
                 rotation: 0.0,
             }
         },
@@ -68,7 +68,7 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
         await Connection.send(CARTA.CloseFile, { fileId: -1 });
     }, connectTimeout);
 
-    describe(`Prepare the first images`, () => {
+    describe(`Prepare the images`, () => {
         test(`Should open image ${assertItem.openFile.file}:`, async () => {
             await Connection.openFile(assertItem.openFile);
         }, openFileTimeout);
@@ -80,6 +80,19 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq.tiles.length);
             expect(ack.RasterTileSync.length).toEqual(2);
         })
+    });
+
+    describe(`Plot multi regions in the spectral profiler:`,()=>{
+        test(`Set two Regions in the images`, async()=>{
+            await Connection.send(CARTA.SetRegion,assertItem.setRegion[0]);
+            let RegionResponse1 = await Connection.receive(CARTA.SetRegionAck);
+            expect(RegionResponse1.regionId).toEqual(1);
+
+            await Connection.send(CARTA.SetRegion,assertItem.setRegion[1]);
+            let RegionResponse2 = await Connection.receive(CARTA.SetRegionAck);
+            expect(RegionResponse2.regionId).toEqual(2);
+        });
+
     });
 
 

--- a/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
@@ -15,7 +15,7 @@ interface AssertItem {
     registerViewer: CARTA.IRegisterViewer;
     openFile: CARTA.IOpenFile;
     addTilesReq: CARTA.IAddRequiredTiles;
-    setCursor: CARTA.ISetCursor;
+    setRegion: CARTA.ISetRegion[];
 }
 let assertItem: AssertItem = {
     precisionDigits: 7,
@@ -25,25 +25,38 @@ let assertItem: AssertItem = {
     },
     openFile: {
         directory: testSubdirectory,
-            file: "HD163296_CO_2_1.fits",
-            fileId: 0,
-            hdu: "",
-            renderMode: CARTA.RenderMode.RASTER,
-        },
+        file: "HD163296_CO_2_1.fits",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
         
-    addTilesReq: 
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [16777216, 16781312, 16777217, 16781313],
+    },
+    setRegion: [
         {
             fileId: 0,
-            compressionQuality: 11,
-            compressionType: CARTA.CompressionType.ZFP,
-            tiles: [16777216, 16781312, 16777217, 16781313],
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 213, y: 277 }, { x: 100, y: 100 }],
+                rotation: 0.0,
+            }
         },
-    setCursor: 
         {
             fileId: 0,
-            point: { x: 216, y: 216 },
-    
-        }, 
+            regionId: -1,
+            regionInfo: {
+                regionType: CARTA.RegionType.RECTANGLE,
+                controlPoints: [{ x: 213, y: 277 }, { x: 100, y: 100 }],
+                rotation: 0.0,
+            }
+        },
+    ]
 };
 
 describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {

--- a/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-REGION.test.ts
@@ -113,7 +113,7 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+describe("MULTI-SPECTRAL-PROFILE-REGION: Test plotting the multi-spectral profiles with two regions in one image", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);

--- a/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
@@ -2,7 +2,7 @@ import { CARTA } from "carta-protobuf";
 import { Client, AckStream } from "./CLIENT";
 import config from "./config.json";
 
-let testServerUrl = config.serverURL0;
+let testServerUrl = config.serverURL;
 let testSubdirectory = config.path.moment;
 let connectTimeout = config.timeout.connection;
 let openFileTimeout = config.timeout.openFile;
@@ -102,11 +102,23 @@ let assertItem: AssertItem = {
         },
         {
             index: 0,
-            value: -0.00023187858529677354,
+            value: 0.0062467408097798246,
         },
         {
             index: 100,
-            value: 0.056362498725418875,
+            value: 0.06037216936383088,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+        {
+            index: 0,
+            value: 0.0062001189561202924,
+        },
+        {
+            index: 100,
+            value: 0.05867533210175882,
         },
         {
             index: 200,
@@ -158,11 +170,22 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[1]);
             let temp2 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
             let SecondStatisticsSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
-            // expect(FirstRegionSpectralProfile.regionId).toEqual(1);
+            expect(SecondStatisticsSpectralProfile.regionId).toEqual(1);
             expect(SecondStatisticsSpectralProfile.progress).toEqual(1);
-            // expect(FirstRegionSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
-            // expect(FirstRegionSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
-            // expect(FirstRegionSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
+            expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
+            expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
+            expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
+        });
+
+        test(`Plot two statistics in the spectral profiles within one SetSpectralRequirement request and check the values`,async()=>{
+            await Connection.send(CARTA.SetSpectralRequirements,assertItem.setSpectralRequirements[2]);
+            let temp3 = await Connection.streamUntil((type, data) => type == CARTA.SpectralProfileData && data.progress == 1);
+            let ThirdStatisticsSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
+            expect(ThirdStatisticsSpectralProfile.regionId).toEqual(1);
+            expect(ThirdStatisticsSpectralProfile.progress).toEqual(1);
+            expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
+            expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
+            expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);
         });
     });
 

--- a/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
@@ -127,7 +127,7 @@ let assertItem: AssertItem = {
     ],
 };
 
-describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+describe("MULTI-SPECTRAL-PROFILE-STATISTIC: Test plotting the multi-spectral profiles with setting multi statistics in one region", () => {
     let Connection: Client;
     beforeAll(async () => {
         Connection = new Client(testServerUrl);
@@ -163,6 +163,7 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let FirstStatisticsSpectralProfile = temp1.SpectralProfileData.slice(-1)[0];
             expect(FirstStatisticsSpectralProfile.regionId).toEqual(1);
             expect(FirstStatisticsSpectralProfile.progress).toEqual(1);
+            expect(FirstStatisticsSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.Mean);
             expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[0].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[0].value,assertItem.precisionDigits);
             expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[1].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[1].value,assertItem.precisionDigits);
             expect(FirstStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[2].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[2].value,assertItem.precisionDigits);
@@ -172,6 +173,7 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let SecondStatisticsSpectralProfile = temp2.SpectralProfileData.slice(-1)[0];
             expect(SecondStatisticsSpectralProfile.regionId).toEqual(1);
             expect(SecondStatisticsSpectralProfile.progress).toEqual(1);
+            expect(SecondStatisticsSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.RMS);
             expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[3].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[3].value,assertItem.precisionDigits);
             expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[4].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[4].value,assertItem.precisionDigits);
             expect(SecondStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[5].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[5].value,assertItem.precisionDigits);
@@ -183,6 +185,7 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
             let ThirdStatisticsSpectralProfile = temp3.SpectralProfileData.slice(-1)[0];
             expect(ThirdStatisticsSpectralProfile.regionId).toEqual(1);
             expect(ThirdStatisticsSpectralProfile.progress).toEqual(1);
+            expect(ThirdStatisticsSpectralProfile.profiles[0].statsType).toEqual(CARTA.StatsType.Sigma);
             expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[6].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[6].value,assertItem.precisionDigits);
             expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[7].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[7].value,assertItem.precisionDigits);
             expect(ThirdStatisticsSpectralProfile.profiles[0].values[assertItem.ReturnSpectralProfileData[8].index]).toBeCloseTo(assertItem.ReturnSpectralProfileData[8].value,assertItem.precisionDigits);

--- a/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
@@ -151,7 +151,7 @@ describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially ma
     });
 
     describe(`Plot multi statistics in one region in the spectral profiler:`,()=>{
-        test(`Set one Regions in the images`, async()=>{
+        test(`Set one Region in the images`, async()=>{
             await Connection.send(CARTA.SetRegion,assertItem.setRegion);
             let RegionResponse1 = await Connection.receive(CARTA.SetRegionAck);
             expect(RegionResponse1.regionId).toEqual(1);

--- a/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
+++ b/src/test/MULTI-SPECTRAL-PROFILE-STATISTIC.test.ts
@@ -1,0 +1,130 @@
+import { CARTA } from "carta-protobuf";
+import { Client, AckStream } from "./CLIENT";
+import config from "./config.json";
+
+let testServerUrl = config.serverURL0;
+let testSubdirectory = config.path.moment;
+let connectTimeout = config.timeout.connection;
+let openFileTimeout = config.timeout.openFile;
+interface ISpectralProfileIndexValue {
+    index: number;
+    value: number;
+}
+interface AssertItem {
+    precisionDigits: number;
+    registerViewer: CARTA.IRegisterViewer;
+    openFile: CARTA.IOpenFile;
+    addTilesReq: CARTA.IAddRequiredTiles;
+    setRegion: CARTA.ISetRegion;
+    setSpectralRequirements: CARTA.ISetSpectralRequirements[];
+    ReturnSpectralProfileData: ISpectralProfileIndexValue[];
+}
+let assertItem: AssertItem = {
+    precisionDigits: 7,
+    registerViewer: {
+        sessionId: 0,
+        clientFeatureFlags: 5,
+    },
+    openFile: {
+        directory: testSubdirectory,
+        file: "HD163296_CO_2_1.fits",
+        fileId: 0,
+        hdu: "",
+        renderMode: CARTA.RenderMode.RASTER,
+    },
+        
+    addTilesReq: {
+        fileId: 0,
+        compressionQuality: 11,
+        compressionType: CARTA.CompressionType.ZFP,
+        tiles: [16777216, 16781312, 16777217, 16781313],
+    },
+    setRegion: {
+        fileId: 0,
+        regionId: -1,
+        regionInfo: {
+            regionType: CARTA.RegionType.RECTANGLE,
+            controlPoints: [{ x: 213, y: 277 }, { x: 100, y: 100 }],
+            rotation: 0.0,
+        }
+    },
+    setSpectralRequirements: [
+        {
+            fileId: 0,
+            regionId: 2,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+        {
+            fileId: 0,
+            regionId: 1,
+            spectralProfiles: [
+                {
+                    coordinate: "z",
+                    statsTypes: [
+                        CARTA.StatsType.Mean,
+                    ],
+                }
+            ],
+        },
+    ],
+    ReturnSpectralProfileData: [
+        {
+            index: 0,
+            value: 0.00030038686512110576,
+        },
+        {
+            index: 100,
+            value: -0.0005688223859330292,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+        {
+            index: 0,
+            value: -0.00023187858529677354,
+        },
+        {
+            index: 100,
+            value: 0.056362498725418875,
+        },
+        {
+            index: 200,
+            value: 0.0,
+        },
+    ],
+};
+
+describe("MATCH_SPATIAL: Test cursor value and spatial profile with spatially matched images", () => {
+    let Connection: Client;
+    beforeAll(async () => {
+        Connection = new Client(testServerUrl);
+        await Connection.open();
+        await Connection.registerViewer(assertItem.registerViewer);
+        await Connection.send(CARTA.CloseFile, { fileId: -1 });
+    }, connectTimeout);
+
+    describe(`Prepare the images`, () => {
+        test(`Should open image ${assertItem.openFile.file}:`, async () => {
+            await Connection.openFile(assertItem.openFile);
+        }, openFileTimeout);
+
+        let ack: AckStream;
+        test(`return RASTER_TILE_DATA(Stream) and check total length `, async()=>{
+            await Connection.send(CARTA.AddRequiredTiles, assertItem.addTilesReq);
+            ack = await Connection.streamUntil((type, data) => type == CARTA.RasterTileSync ? data.endSync : false);
+            expect(ack.RasterTileData.length).toEqual(assertItem.addTilesReq.tiles.length);
+            expect(ack.RasterTileSync.length).toEqual(2);
+        })
+    });
+
+
+    afterAll(() => Connection.close());
+});


### PR DESCRIPTION
Close #285 
I have run the ICD tests on almac(MacOS) and the new 'carta' server (but `let testSubdirectory = config.path.root;`). They are all working fine.

The designed document is [here](https://docs.google.com/document/d/1cb-yFYmc6Ig5tjwuQqgmqzVSi_wvxAs1kOt9WpGY9Ic/edit#)

Because the rawValuesFp64 has transfer to the float number inside the CLIENT.ts (using the same code to the frontend), I match the float number directly instead of check rawValuesFp64.