### PR TITLE
updating tests for 845_add_range_info

### DIFF
--- a/src/test/FILEINFO_FITS_MULTIHDU.test.ts
+++ b/src/test/FILEINFO_FITS_MULTIHDU.test.ts
@@ -58,6 +58,8 @@ let assertItem: AssertItem = {
                     { name: "Celestial frame", value: "FK5, J2000" },
                     { name: "Pixel unit", value: "MJy/sr" },
                     { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "Right Ascension Range", value: "[07:15:06.258, 07:01:59.873]" },
+                    { name: "Declination Range", value: "[-12.14.22.907, -08.51.38.954]" },
                 ],
                 headerEntries: [
                     { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },
@@ -155,6 +157,8 @@ let assertItem: AssertItem = {
                     { name: "Celestial frame", value: "FK5, J2000" },
                     { name: "Pixel unit", value: "MJy/sr" },
                     { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "Right Ascension Range", value: "[07:15:06.258, 07:01:59.873]" },
+                    { name: "Declination Range", value: "[-12.14.22.907, -08.51.38.954]" },
                 ],
                 headerEntries: [
                     { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },
@@ -252,6 +256,8 @@ let assertItem: AssertItem = {
                     { name: "Celestial frame", value: "FK5, J2000" },
                     { name: "Pixel unit", value: "1" },
                     { name: "Pixel increment", value: "-14\", 14\"" },
+                    { name: "Right Ascension Range", value: "[07:15:06.258, 07:01:59.873]" },
+                    { name: "Declination Range", value: "[-12.14.22.907, -08.51.38.954]" },
                 ],
                 headerEntries: [
                     { name: "XTENSION", value: "IMAGE", comment: ' Java FITS: Wed Oct 01 10:15:59 CEST 2014' },

--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -152,9 +152,9 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 15`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(15);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -152,9 +152,9 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 15`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(15);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -152,9 +152,9 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 15`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(15);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
             });
         });
 


### PR DESCRIPTION
This should allow the ICD tests to pass on the `mark/845_add_range_info` carta_backend branch.
The modifications are made from the latest ICD version 26 ICD-test branch, so the tests will only pass properly after `mark/845_add_range_info` is merged into `dev`. We can merge this branch after that happens.