### PR TITLE
updating ICD tests

### DIFF
--- a/src/test/MOMENTS_GENERATOR_CASA.test.ts
+++ b/src/test/MOMENTS_GENERATOR_CASA.test.ts
@@ -146,15 +146,15 @@ describe("MOMENTS_GENERATOR_CASA: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 654`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 85`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(654);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(85);
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 19`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(19);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_FITS.test.ts
+++ b/src/test/MOMENTS_GENERATOR_FITS.test.ts
@@ -146,15 +146,15 @@ describe("MOMENTS_GENERATOR_FITS: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 652`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 85`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(652);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(85);
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 19`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(19);
             });
         });
 

--- a/src/test/MOMENTS_GENERATOR_HDF5.test.ts
+++ b/src/test/MOMENTS_GENERATOR_HDF5.test.ts
@@ -146,15 +146,15 @@ describe("MOMENTS_GENERATOR_HDF5: Testing moments generator for a given region o
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 79`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.headerEntries.length = 90`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.headerEntries.length).toEqual(79);
+                expect(ack.fileInfoExtended.headerEntries.length).toEqual(90);
             });
         });
 
-        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 18`, () => {
+        test(`Assert openFileAcks[].fileInfoExtended.computedEntries.length = 19`, () => {
             ack.MomentResponse[0].openFileAcks.map((ack, index) => {
-                expect(ack.fileInfoExtended.computedEntries.length).toEqual(18);
+                expect(ack.fileInfoExtended.computedEntries.length).toEqual(19);
             });
         });
 


### PR DESCRIPTION
This should update the three Moments ICD tests to work with the carta-backend [PR#1091](https://github.com/CARTAvis/carta-backend/pull/1091) that added moment map generation information to FITS header.

- src/test/MOMENTS_GENERATOR_CASA.test.ts
- src/test/MOMENTS_GENERATOR_FITS.test.ts
- src/test/MOMENTS_GENERATOR_HDF5.test.ts